### PR TITLE
Using real context to shutdown metrics HTTP server. 

### DIFF
--- a/metrics/transport.go
+++ b/metrics/transport.go
@@ -119,7 +119,7 @@ func PullMetrics(ctx context.Context, metricsPort int, actions []string) error {
 	go func() {
 		<-ctx.Done()
 		//nolint:staticcheck
-		if err := srv.Shutdown(nil); err != nil {
+		if err := srv.Shutdown(context.Background()); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Httpserver: Shutdown() error: %s", err)
 		}
 	}()

--- a/metrics/transport.go
+++ b/metrics/transport.go
@@ -119,7 +119,9 @@ func PullMetrics(ctx context.Context, metricsPort int, actions []string) error {
 	go func() {
 		<-ctx.Done()
 		//nolint:staticcheck
-		if err := srv.Shutdown(context.Background()); err != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Httpserver: Shutdown() error: %s", err)
 		}
 	}()


### PR DESCRIPTION
Using real context to shutdown metrics HTTP server. A nil context is not safe towards the http package and will on occasion cause panic

**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**
Using real context to shutdown metrics HTTP server. A nil context is not safe towards the http package and will on occasion cause panic