### PR TITLE
Enhancement/569 change reuse user randomizer

### DIFF
--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -726,7 +726,7 @@ Each action executed by `randomaction` is followed by a customizable `thinktime`
       * `uniform`: Random think time with uniform distribution, defined by `mean` and `dev`.
   * `delay`: Delay (seconds), used with type `static`.
   * `mean`: Mean (seconds), used with type `uniform`.
-  * `dev`: Deviation (seconds), used with type `uniform`.
+  * `dev`: Deviation (seconds) from `mean` value, used with type `uniform`.
 * `iterations`: Number of random actions to perform.
 
 ### Random action defaults
@@ -1037,11 +1037,13 @@ Simulate user think time.
     * `uniform`: Random think time with uniform distribution, defined by `mean` and `dev`.
 * `delay`: Delay (seconds), used with type `static`.
 * `mean`: Mean (seconds), used with type `uniform`.
-* `dev`: Deviation (seconds), used with type `uniform`.
+* `dev`: Deviation (seconds) from `mean` value, used with type `uniform`.
 
 ### Examples
 
 #### ThinkTime uniform
+
+This would simulate a think time between 10 and 15 seconds.
 
 ```json
 {
@@ -1056,6 +1058,8 @@ Simulate user think time.
 ```
 
 #### ThinkTime constant
+
+This would simulate a think time of 5 seconds.
 
 ```json
 {

--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -1043,7 +1043,7 @@ Simulate user think time.
 
 #### ThinkTime uniform
 
-This would simulate a think time between 10 and 15 seconds.
+This simulates a think time of 10 to 15 seconds.
 
 ```json
 {
@@ -1059,7 +1059,7 @@ This would simulate a think time between 10 and 15 seconds.
 
 #### ThinkTime constant
 
-This would simulate a think time of 5 seconds.
+This simulates a think time of 5 seconds.
 
 ```json
 {

--- a/generatedocs/data/actions/thinktime/examples.md
+++ b/generatedocs/data/actions/thinktime/examples.md
@@ -2,7 +2,7 @@
 
 #### ThinkTime uniform
 
-This would simulate a think time between 10 and 15 seconds.
+This simulates a think time of 10 to 15 seconds.
 
 ```json
 {
@@ -18,7 +18,7 @@ This would simulate a think time between 10 and 15 seconds.
 
 #### ThinkTime constant
 
-This would simulate a think time of 5 seconds.
+This simulates a think time of 5 seconds.
 
 ```json
 {

--- a/generatedocs/data/actions/thinktime/examples.md
+++ b/generatedocs/data/actions/thinktime/examples.md
@@ -2,6 +2,8 @@
 
 #### ThinkTime uniform
 
+This would simulate a think time between 10 and 15 seconds.
+
 ```json
 {
      "label": "TimerDelay",
@@ -15,6 +17,8 @@
 ```
 
 #### ThinkTime constant
+
+This would simulate a think time of 5 seconds.
 
 ```json
 {

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -525,7 +525,7 @@
         "Mean (seconds), used with type `uniform`."
     ],
     "thinktime.dev": [
-        "Deviation (seconds), used with type `uniform`."
+        "Deviation (seconds) from `mean` value, used with type `uniform`."
     ],
     "unpublishsheet.mode": [
         "",

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -161,7 +161,7 @@ var (
         },
         "thinktime": {
             Description: "## ThinkTime action\n\nSimulate user think time.\n\n**Note:** This action does not require an app context (that is, it does not have to be prepended with an `openapp` action).\n",
-            Examples: "### Examples\n\n#### ThinkTime uniform\n\nThis would simulate a think time between 10 and 15 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"uniform\",\n         \"mean\": 12.5,\n         \"dev\": 2.5\n     } \n} \n```\n\n#### ThinkTime constant\n\nThis would simulate a think time of 5 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"static\",\n         \"delay\": 5\n     }\n}\n```\n",
+            Examples: "### Examples\n\n#### ThinkTime uniform\n\nThis simulates a think time of 10 to 15 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"uniform\",\n         \"mean\": 12.5,\n         \"dev\": 2.5\n     } \n} \n```\n\n#### ThinkTime constant\n\nThis simulates a think time of 5 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"static\",\n         \"delay\": 5\n     }\n}\n```\n",
         },
         "unpublishsheet": {
             Description: "## UnpublishSheet action\n\nUnpublish sheets in the current app.\n",

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -161,7 +161,7 @@ var (
         },
         "thinktime": {
             Description: "## ThinkTime action\n\nSimulate user think time.\n\n**Note:** This action does not require an app context (that is, it does not have to be prepended with an `openapp` action).\n",
-            Examples: "### Examples\n\n#### ThinkTime uniform\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"uniform\",\n         \"mean\": 12.5,\n         \"dev\": 2.5\n     } \n} \n```\n\n#### ThinkTime constant\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"static\",\n         \"delay\": 5\n     }\n}\n```\n",
+            Examples: "### Examples\n\n#### ThinkTime uniform\n\nThis would simulate a think time between 10 and 15 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"uniform\",\n         \"mean\": 12.5,\n         \"dev\": 2.5\n     } \n} \n```\n\n#### ThinkTime constant\n\nThis would simulate a think time of 5 seconds.\n\n```json\n{\n     \"label\": \"TimerDelay\",\n     \"action\": \"thinktime\",\n     \"settings\": {\n         \"type\": \"static\",\n         \"delay\": 5\n     }\n}\n```\n",
         },
         "unpublishsheet": {
             Description: "## UnpublishSheet action\n\nUnpublish sheets in the current app.\n",
@@ -318,7 +318,7 @@ var (
         "staticselect.type": { "Selection type","`hypercubecells`: Select in hypercube.","`listobjectvalues`: Select in listbox."  },  
         "staticselect.wrap": { "Wrap selection with Begin / End selection requests (`true` / `false`)."  },  
         "thinktime.delay": { "Delay (seconds), used with type `static`."  },  
-        "thinktime.dev": { "Deviation (seconds), used with type `uniform`."  },  
+        "thinktime.dev": { "Deviation (seconds) from `mean` value, used with type `uniform`."  },  
         "thinktime.mean": { "Mean (seconds), used with type `uniform`."  },  
         "thinktime.type": { "Type of think time","`static`: Static think time, defined by `delay`.","`uniform`: Random think time with uniform distribution, defined by `mean` and `dev`."  },  
         "unpublishsheet.mode": { "","`allsheets`: Unpublish all sheets in the app.","`sheetids`: Only unpublish the sheets specified by the `sheetIds` array."  },  

--- a/helpers/distribution.go
+++ b/helpers/distribution.go
@@ -2,12 +2,10 @@ package helpers
 
 import (
 	"fmt"
-	"strconv"
-	"math/rand"
-
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/enummap"
-	"github.com/qlik-oss/gopherciser/randomizer"
+	"strconv"
+	"time"
 )
 
 type (
@@ -34,7 +32,8 @@ const (
 	UniformDistribution
 )
 
-func (value DistributionType) GetEnumMap() *enummap.EnumMap{
+// GetEnumMap of DistributionType
+func (value DistributionType) GetEnumMap() *enummap.EnumMap {
 	enumMap, _ := enummap.NewEnumMap(map[string]int{
 		"static":  int(StaticDistribution),
 		"uniform": int(UniformDistribution),
@@ -62,6 +61,7 @@ func (value DistributionType) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, str)), nil
 }
 
+// Validate DistributionSettings
 func (settings DistributionSettings) Validate() error {
 	switch settings.Type {
 	case StaticDistribution:
@@ -89,21 +89,22 @@ func (settings DistributionSettings) Validate() error {
 	return nil
 }
 
-func (settings DistributionSettings) GetSample(rnd *randomizer.Randomizer) (float64, error) {
+// RandDuration returns a random duration
+func (settings DistributionSettings) RandDuration(rnd Randomizer) (time.Duration, error) {
 	switch settings.Type {
 	case StaticDistribution:
-		return settings.Delay, nil
+		return time.Duration(settings.Delay * float64(time.Second)), nil
 	case UniformDistribution:
-		min := settings.Mean - settings.Deviation
-		max := settings.Mean + settings.Deviation
-		delay := (rand.Float64() * (max-min)) + min
-		return delay, nil
+		min := time.Duration(float64(time.Second) * (settings.Mean - settings.Deviation))
+		max := time.Duration(float64(time.Second) * (settings.Mean + settings.Deviation))
+		return rnd.RandDuration(min, max)
 	default:
 		return 0, errors.Errorf("distribution type<%d> not yet supported", settings.Type)
 	}
 }
 
-func (settings DistributionSettings) GetMax(rnd *randomizer.Randomizer) (float64, error) {
+// GetMax value
+func (settings DistributionSettings) GetMax() (float64, error) {
 	switch settings.Type {
 	case StaticDistribution:
 		return settings.Delay, nil
@@ -115,7 +116,8 @@ func (settings DistributionSettings) GetMax(rnd *randomizer.Randomizer) (float64
 	}
 }
 
-func (settings DistributionSettings) GetMin(rnd *randomizer.Randomizer) (float64, error) {
+// GetMin value
+func (settings DistributionSettings) GetMin() (float64, error) {
 	switch settings.Type {
 	case StaticDistribution:
 		return settings.Delay, nil
@@ -127,6 +129,7 @@ func (settings DistributionSettings) GetMin(rnd *randomizer.Randomizer) (float64
 	}
 }
 
+// GetActionInfo get information for action details logging
 func (settings DistributionSettings) GetActionInfo() string {
 	switch settings.Type {
 	case StaticDistribution:

--- a/helpers/randomizer.go
+++ b/helpers/randomizer.go
@@ -1,0 +1,11 @@
+package helpers
+
+import "time"
+
+type Randomizer interface {
+	Rand(max int) int
+	RandWeightedInt(weights []int) (int, error)
+	RandIntPos(ints []int) (int, int, error)
+	RandDuration(minDuration, maxDuration time.Duration) (time.Duration, error)
+	Reset(instance, session uint64, onlyinstanceSeed bool)
+}

--- a/scenario/select.go
+++ b/scenario/select.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"context"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"math"
 	"sort"
 	"strconv"
@@ -16,7 +17,6 @@ import (
 	"github.com/qlik-oss/gopherciser/enummap"
 	"github.com/qlik-oss/gopherciser/globals/constant"
 	"github.com/qlik-oss/gopherciser/logger"
-	"github.com/qlik-oss/gopherciser/randomizer"
 	"github.com/qlik-oss/gopherciser/senseobjdef"
 	"github.com/qlik-oss/gopherciser/session"
 )
@@ -465,7 +465,7 @@ func getHyperCubeCardinal(objId string, dimension int, hypercube *enigmahandlers
 	return dimInfo.Cardinal, nil
 }
 
-func getSelectQty(min, max, possible int, rnd *randomizer.Randomizer) int {
+func getSelectQty(min, max, possible int, rnd helpers.Randomizer) int {
 	localMin := min
 	localMax := max
 
@@ -488,7 +488,7 @@ func getSelectQty(min, max, possible int, rnd *randomizer.Randomizer) int {
 	return rnd.Rand(localMax-localMin+1) + localMin
 }
 
-func fillSelectPosFromAll(min, max, cardinal int, rnd *randomizer.Randomizer) ([]int, error) {
+func fillSelectPosFromAll(min, max, cardinal int, rnd helpers.Randomizer) ([]int, error) {
 	if rnd == nil {
 		return nil, errors.Errorf("Randomizer not provided")
 	}
@@ -532,7 +532,7 @@ func fillSelectPosFromAll(min, max, cardinal int, rnd *randomizer.Randomizer) ([
 	return selectPos.Array(), nil
 }
 
-func fillSelectPosFromPossible(min, max int, possible []int, rnd *randomizer.Randomizer) ([]int, error) {
+func fillSelectPosFromPossible(min, max int, possible []int, rnd helpers.Randomizer) ([]int, error) {
 	if rnd == nil {
 		return nil, errors.Errorf("Randomizer not provided")
 	}
@@ -581,7 +581,7 @@ func fillSelectPosFromPossible(min, max int, possible []int, rnd *randomizer.Ran
 	return selectPos.Array(), nil
 }
 
-func fillSelectBinsFromBins(min, max int, bins []string, rnd *randomizer.Randomizer) ([]string, error) {
+func fillSelectBinsFromBins(min, max int, bins []string, rnd helpers.Randomizer) ([]string, error) {
 	if rnd == nil {
 		return nil, errors.Errorf("Randomizer not provided")
 	}

--- a/scenario/select_test.go
+++ b/scenario/select_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/qlik-oss/gopherciser/randomizer"
 )
 
+type Rnd struct {
+	*randomizer.Randomizer
+}
+
+func (rnd *Rnd) Reset(instance, session uint64, onlyinstanceSeed bool) {
+	rnd.Randomizer = randomizer.NewSeededRandomizer(randomizer.GetPredictableSeed(int(instance), int(session)))
+}
+
 func TestSelectUnmarshal(t *testing.T) {
 	t.Parallel()
 
@@ -117,7 +125,8 @@ func TestValidate(t *testing.T) {
 func TestSelectQty(t *testing.T) {
 	t.Parallel()
 
-	rnd := randomizer.NewSeededRandomizer(randomizer.GetPredictableSeedUInt64(1, 2))
+	rnd := &Rnd{}
+	rnd.Reset(1, 2, false)
 
 	v := getSelectQty(2, 5, 5, rnd)
 	validateInt(t, "selectqty", v, 4)
@@ -178,7 +187,8 @@ func TestCutSlice(t *testing.T) {
 func TestFillPos(t *testing.T) {
 	t.Parallel()
 
-	rnd := randomizer.NewSeededRandomizer(randomizer.GetPredictableSeedUInt64(1, 3245345))
+	rnd := &Rnd{}
+	rnd.Reset(1, 3245345, false)
 
 	selectPos, err := fillSelectPosFromAll(3, 6, 5, rnd)
 	if err != nil {

--- a/scenario/thinktime.go
+++ b/scenario/thinktime.go
@@ -30,13 +30,12 @@ func (settings ThinkTimeSettings) Execute(sessionState *session.State, actionSta
 		sessionState.LogEntry.Log(logger.WarningLevel, "Faking sent message in timer delay failed")
 	}
 
-	seconds, err := settings.DistributionSettings.GetSample(sessionState.Randomizer())
-	delay := time.Duration(int(seconds*1000000000)) * time.Nanosecond
+	delay, err := settings.DistributionSettings.RandDuration(sessionState.Randomizer())
 	if err != nil {
 		actionState.AddErrors(errors.WithStack(err))
 		return
 	}
-	if seconds < nanosecond {
+	if delay < time.Nanosecond {
 		actionState.AddErrors(errors.New("timer delay not set"))
 		return
 	}

--- a/scenario/thinktime.go
+++ b/scenario/thinktime.go
@@ -13,8 +13,6 @@ import (
 	"github.com/qlik-oss/gopherciser/session"
 )
 
-const nanosecond float64 = 0.000000001
-
 type (
 	// ThinkTimeSettings think time settings
 	ThinkTimeSettings struct {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -191,6 +191,11 @@ func (sched *Scheduler) startNewUser(ctx context.Context, timeout time.Duration,
 			break
 		}
 
+		if iteration > 1 {
+			sessionID := globals.Sessions.Inc()
+			sessionState.Randomizer().Reset(instanceID, sessionID, onlyInstanceSeed)
+		}
+
 		setLogEntry(sessionState, log, sessionID, thread, userName)
 
 		err := sched.runIteration(userScenario, sessionState, mErr, ctx)

--- a/scheduler/simple.go
+++ b/scheduler/simple.go
@@ -94,7 +94,7 @@ func (sched SimpleScheduler) Execute(ctx context.Context, log *logger.Log, timeo
 		go func() {
 			defer wg.Done()
 
-			if err := sched.iteratorNewUsers(ctx, timeout, log, scenario, outputsDir, users); err != nil {
+			if err := sched.iterator(ctx, timeout, log, scenario, outputsDir, users); err != nil {
 				func() { // wrapped in function to minimize locking time
 					mErrLock.Lock()
 					defer mErrLock.Unlock()
@@ -109,7 +109,7 @@ func (sched SimpleScheduler) Execute(ctx context.Context, log *logger.Log, timeo
 	return errors.WithStack(helpers.FlattenMultiError(mErr))
 }
 
-func (sched SimpleScheduler) iteratorNewUsers(ctx context.Context, timeout time.Duration, log *logger.Log,
+func (sched SimpleScheduler) iterator(ctx context.Context, timeout time.Duration, log *logger.Log,
 	scenario []scenario.Action, outputsDir string, users users.UserGenerator) (err error) {
 
 	thread := globals.Threads.Inc()

--- a/scheduler/simple_test.go
+++ b/scheduler/simple_test.go
@@ -139,6 +139,7 @@ func TestReuseUserRandomizer(t *testing.T) {
 	}
 	actions, resultP := FillScenario(actionsToAdd)
 
+	globals.Sessions.Reset()
 	runUserIterationReuseUser(t, sched, actions)
 	sched.Settings.Iterations = 2
 	globals.Sessions.Reset()

--- a/scheduler/simple_test.go
+++ b/scheduler/simple_test.go
@@ -185,7 +185,7 @@ func runUserIterationReuseUser(t *testing.T, sched *SimpleScheduler, actions []s
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	if err := sched.iteratorReuseUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
+	if err := sched.iteratorNewUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/scheduler/simple_test.go
+++ b/scheduler/simple_test.go
@@ -148,6 +148,11 @@ func TestReuseUserRandomizer(t *testing.T) {
 	result := *resultP
 	t.Log("results:", result)
 
+	// verify we have expected amount of results
+	if len(result) != actionsToAdd*2 {
+		t.Fatalf("results not of expected length<%d>", actionsToAdd*2)
+	}
+
 	// divide into 4 sequences
 	var seqDiv = actionsToAdd / 2
 	seq1 := result[:seqDiv]

--- a/scheduler/simple_test.go
+++ b/scheduler/simple_test.go
@@ -2,16 +2,16 @@ package scheduler
 
 import (
 	"context"
+	"github.com/qlik-oss/gopherciser/globals"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/action"
+	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/scenario"
 	"github.com/qlik-oss/gopherciser/session"
 	"github.com/qlik-oss/gopherciser/users"
-
-	"github.com/pkg/errors"
-	"github.com/qlik-oss/gopherciser/connection"
 )
 
 func TestSimpleSched(t *testing.T) {
@@ -55,14 +55,14 @@ func TestSimpleSched(t *testing.T) {
 	}
 }
 
-type TestOnlyInstanceSeedAction struct {
+type resultCollectorAction struct {
 	Result []int
 }
 
-func (settings TestOnlyInstanceSeedAction) Validate() error {
+func (settings resultCollectorAction) Validate() error {
 	return nil
 }
-func (settings *TestOnlyInstanceSeedAction) Execute(sessionState *session.State,
+func (settings *resultCollectorAction) Execute(sessionState *session.State,
 	actionState *action.State, connectionSettings *connection.ConnectionSettings, label string, reset func()) {
 	settings.Result = append(settings.Result, sessionState.Randomizer().Rand(100))
 }
@@ -90,20 +90,13 @@ func TestOnlyInstanceSeed(t *testing.T) {
 	sched2 := &deRef
 	sched2.Settings.OnlyInstanceSeed = false
 
-	actionSettings := &TestOnlyInstanceSeedAction{}
-	testAction := scenario.Action{ActionCore: scenario.ActionCore{}, Settings: actionSettings}
-
 	actionsToAdd := 10
-
-	actions := make([]scenario.Action, 0, actionsToAdd)
-	for i := 0; i < actionsToAdd; i++ {
-		actions = append(actions, testAction)
-	}
+	actions, resultP := FillScenario(actionsToAdd)
 
 	runUserIteration(t, sched1, actions)
 	runUserIteration(t, sched2, actions)
 
-	result := actionSettings.Result
+	result := *resultP
 	t.Log("results:", result)
 
 	// check we have to correct amount of results
@@ -112,26 +105,66 @@ func TestOnlyInstanceSeed(t *testing.T) {
 	}
 
 	// sched 1 iteration 1 and 2 sequences should be the same
-	seq11 := result[0:actionsToAdd]
-	seq12 := result[actionsToAdd:(actionsToAdd * 2)]
-	for i := 0; i < actionsToAdd; i++ {
-		if seq11[i] != seq12[i] {
-			t.Fatalf("iteration sequences differs although using OnlyInstanceSeed flag, sequences: 1<%v> 2<%v>", seq11, seq12)
-		}
+	if err := compareSequenceEqual(result[0:actionsToAdd], result[actionsToAdd:(actionsToAdd*2)]); err != nil {
+		t.Fatalf("iteration sequences differs although using OnlyInstanceSeed flag: %v", err)
 	}
 
 	// sched 1 results should differ from sched 2 results
-	seq1 := result[0:(actionsToAdd * iterations)]
-	seq2 := result[(actionsToAdd * iterations):(actionsToAdd * iterations * 2)]
-	differenceFound := false
-	for i := 0; i < actionsToAdd*iterations; i++ {
-		if seq1[i] != seq2[i] {
-			differenceFound = true
-			break
-		}
+	if err := compareSequenceNotEqual(result[0:(actionsToAdd*iterations)], result[(actionsToAdd*iterations):(actionsToAdd*iterations*2)]); err != nil {
+		t.Fatalf("scheduler sequences doesn't differ when using OnlyInstanceSeed and not, %v", err)
 	}
-	if !differenceFound {
-		t.Fatalf("scheduler sequences doesn't differ when using OnlyInstanceSeed and not, sequences: 1<%v> 2<%v>", seq1, seq2)
+}
+
+func TestReuseUserRandomizer(t *testing.T) {
+	// Test to make sure each iteration of re-use users has a unique randomizer
+	sched := &SimpleScheduler{
+		Scheduler: Scheduler{
+			SchedType:          SchedSimple,
+			InstanceNumber:     1,
+			connectionSettings: &connection.ConnectionSettings{},
+		},
+		Settings: SimpleSchedSettings{
+			ExecutionTime:    -1,
+			Iterations:       1,
+			RampupDelay:      0.1,
+			ConcurrentUsers:  1,
+			ReuseUsers:       true,
+			OnlyInstanceSeed: false,
+		},
+	}
+
+	actionsToAdd := 16
+	if actionsToAdd%2 != 0 { // actionsToAdd need to be an even number
+		t.Fatalf("actionsToAdd<%d> not divisible by 2", actionsToAdd)
+	}
+	actions, resultP := FillScenario(actionsToAdd)
+
+	runUserIterationReuseUser(t, sched, actions)
+	sched.Settings.Iterations = 2
+	globals.Sessions.Reset()
+	runUserIterationReuseUser(t, sched, actions[:(actionsToAdd/2)])
+
+	result := *resultP
+	t.Log("results:", result)
+
+	// divide into 4 sequences
+	var seqDiv = actionsToAdd / 2
+	seq1 := result[:seqDiv]
+	seq2 := result[seqDiv : seqDiv*2]
+	seq3 := result[seqDiv*2 : seqDiv*3]
+	seq4 := result[seqDiv*3:]
+
+	t.Logf("seq1: %v\n", seq1)
+	t.Logf("seq2: %v\n", seq2)
+	t.Logf("seq3: %v\n", seq3)
+	t.Logf("seq4: %v\n", seq4)
+
+	if err := compareSequenceEqual(seq1, seq3); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compareSequenceNotEqual(seq2, seq4); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -144,4 +177,56 @@ func runUserIteration(t *testing.T, sched *SimpleScheduler, actions []scenario.A
 	if err := sched.iteratorNewUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func runUserIterationReuseUser(t *testing.T, sched *SimpleScheduler, actions []scenario.Action) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	if err := sched.iteratorReuseUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func FillScenario(actionsToAdd int) ([]scenario.Action, *[]int) {
+	actionSettings := &resultCollectorAction{}
+	testAction := scenario.Action{ActionCore: scenario.ActionCore{}, Settings: actionSettings}
+
+	actions := make([]scenario.Action, 0, actionsToAdd)
+	for i := 0; i < actionsToAdd; i++ {
+		actions = append(actions, testAction)
+	}
+	return actions, &actionSettings.Result
+}
+
+func compareSequenceEqual(seq1, seq2 []int) error {
+	len1 := len(seq1)
+	if len(seq2) != len1 {
+		return errors.Errorf("%v and %v of different lengths", seq1, seq2)
+	}
+
+	for i := 0; i < len1; i++ {
+		if seq1[i] != seq2[i] {
+			return errors.Errorf("sequence<%v> and sequence<%v> not equal", seq1, seq2)
+		}
+	}
+
+	return nil
+}
+
+func compareSequenceNotEqual(seq1, seq2 []int) error {
+	len1 := len(seq1)
+	if len(seq2) != len1 {
+		return errors.Errorf("%v and %v of different lengths", seq1, seq2)
+	}
+
+	for i := 0; i < len1; i++ {
+		if seq1[i] != seq2[i] {
+			return nil // difference found
+		}
+	}
+
+	return errors.Errorf("sequence<%v> and sequence<%v> are equal", seq1, seq2)
 }

--- a/scheduler/simple_test.go
+++ b/scheduler/simple_test.go
@@ -180,7 +180,7 @@ func runUserIteration(t *testing.T, sched *SimpleScheduler, actions []scenario.A
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	if err := sched.iteratorNewUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
+	if err := sched.iterator(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -191,7 +191,7 @@ func runUserIterationReuseUser(t *testing.T, sched *SimpleScheduler, actions []s
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	if err := sched.iteratorNewUsers(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
+	if err := sched.iterator(ctx, time.Minute, nil, actions, "", users.NewUserGeneratorNone()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/session/artifactmap_test.go
+++ b/session/artifactmap_test.go
@@ -1,10 +1,10 @@
 package session
 
 import (
+	"github.com/qlik-oss/gopherciser/randomizer"
 	"sync"
 	"testing"
 
-	"github.com/qlik-oss/gopherciser/randomizer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -51,8 +51,11 @@ var (
 
 	dummyState = &State{
 		rand: &rand{
-			mu:  sync.Mutex{},
-			rnd: randomizer.NewRandomizer(),
+			mu: sync.Mutex{},
+			rnd: &DefaultRandomizer{
+				sync.Mutex{},
+				randomizer.NewRandomizer(),
+			},
 		},
 	}
 )

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -124,12 +124,14 @@ func New(ctx context.Context, outputsDir string, timeout time.Duration,
 		state.Timeout = DefaultTimeout
 	}
 
+	var seed int64
 	if onlyInstanceSeed {
 		// Use same random sequence for all users
-		session = 1
+		seed = randomizer.GetPredictableSeedUInt64(instance, 1)
+	} else {
+		seed = randomizer.GetPredictableSeedUInt64(instance, session)
 	}
-	rnd := randomizer.NewSeededRandomizer(randomizer.GetPredictableSeedUInt64(instance, session))
-	state.SetRandomizer(rnd, false)
+	state.SetRandomizer(randomizer.NewSeededRandomizer(seed), false)
 
 	return state
 }


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

* Make session id count also for reuse user iterations
* Determinism not broken due to a failed iteration when using reuse user flag
* Bugfix for determinsm and thinktime actions
* Randomizer can now be overriden by other by users or future schedulers
