### PR TITLE
metrics: Add gopherciser_build_info metric

### DIFF
--- a/metrics/custom.go
+++ b/metrics/custom.go
@@ -4,11 +4,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	promNS = "gopherciser"
+)
+
 // GopherActions action counter
 var GopherActions = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "gopherciser_actions_total",
-		Help: "Number of gopherciser actions and their result. DOES NOT USE LABEL!",
+		Namespace: promNS,
+		Name:      "actions_total",
+		Help:      "Number of gopherciser actions and their result. DOES NOT USE LABEL!",
 	},
 	[]string{"result", "action"},
 )
@@ -16,8 +21,9 @@ var GopherActions = prometheus.NewCounterVec(
 // GopherWarnings execution Warnings
 var GopherWarnings = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "gopherciser_warnings_total",
-		Help: "Number of gopherciser execution warnings per action/label.",
+		Namespace: promNS,
+		Name:      "warnings_total",
+		Help:      "Number of gopherciser execution warnings per action/label.",
 	},
 	[]string{"action"},
 )
@@ -25,28 +31,32 @@ var GopherWarnings = prometheus.NewCounterVec(
 // GopherErrors execution Errors
 var GopherErrors = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
-		Name: "gopherciser_errors_per_action",
-		Help: "Number of gopherciser execution errors per action/label and app.",
+		Namespace: promNS,
+		Name:      "errors_per_action",
+		Help:      "Number of gopherciser execution errors per action/label and app.",
 	},
 	[]string{"action"},
 )
 
 // GopherUsersTotal simulated users
 var GopherUsersTotal = prometheus.NewCounter(prometheus.CounterOpts{
-	Name: "gopherciser_users_total",
-	Help: "Number of gopherciser users simulated.",
+	Namespace: promNS,
+	Name:      "users_total",
+	Help:      "Number of gopherciser users simulated.",
 })
 
 // GopherActiveUsers currently active
 var GopherActiveUsers = prometheus.NewGauge(prometheus.GaugeOpts{
-	Name: "gopherciser_active_users",
-	Help: "Current amount of active users",
+	Namespace: promNS,
+	Name:      "active_users",
+	Help:      "Current amount of active users",
 })
 
 // GopherResponseTimes response times
 var GopherResponseTimes = prometheus.NewSummaryVec(
 	prometheus.SummaryOpts{
-		Name:       "gopherciser_response_times",
+		Namespace:  promNS,
+		Name:       "response_times",
 		Help:       "Summarized response times per action/label",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	},
@@ -56,11 +66,22 @@ var GopherResponseTimes = prometheus.NewSummaryVec(
 // GopherActionLatencyHist is a histogram tracking the response times of actions
 var GopherActionLatencyHist = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
-		Name:    "gopherciser_response_times_seconds",
-		Help:    "latency of actions/label",
-		Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 2, 4, 6},
+		Namespace: promNS,
+		Name:      "response_times_seconds",
+		Help:      "latency of actions/label",
+		Buckets:   []float64{0.01, 0.05, 0.1, 0.5, 1, 2, 4, 6},
 	},
 	[]string{"action"},
+)
+
+// BuildInfo -
+var BuildInfo = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: promNS,
+		Name:      "build_info",
+		Help:      "A constant metric labeled with build information for " + promNS,
+	},
+	[]string{"version", "revision", "goversion", "goarch", "goos"},
 )
 
 //GopherRegistry registers the metrics in a registry to be used for prometheus push


### PR DESCRIPTION
It's conventional to have a `*_build_info` metric (a gauge always set to `1`), with labels to indicate the current-running version. See https://www.robustperception.io/exposing-the-software-version-to-prometheus for more information on this convention.

We had some confusion around which version was running (due to missing metrics), and this would've helped us troubleshoot faster.

Signed-off-by: Dave Henderson <David.Henderson@qlik.com>