### PR TITLE
avoid nilpointer exception when using objects without select definitions in select action

### DIFF
--- a/scenario/select.go
+++ b/scenario/select.go
@@ -830,6 +830,11 @@ func DoSelect(sessionState *session.State, actionState *action.State, genObj *en
 		return
 	}
 
+	if selectType == senseobjdef.SelectTypeUnknown {
+		actionState.AddErrors(errors.Errorf("object<%s> type<%s> does not have a select definition", genObj.GenericId, genObj.Type))
+		return
+	}
+
 	if wrap {
 		// Start selections
 		sessionState.QueueRequest(func(ctx context.Context) error {

--- a/session/defaulthandler.go
+++ b/session/defaulthandler.go
@@ -74,5 +74,14 @@ func (instance *DefaultHandlerInstance) GetObjectDefinition(objectType string) (
 	if validateErr := def.Validate(); validateErr != nil {
 		return "", senseobjdef.SelectTypeUnknown, senseobjdef.DataDefUnknown, errors.Wrapf(validateErr, "Error validating object<%s> selection definitions<%+v>", objectType, def)
 	}
-	return def.Select.Path, def.Select.Type, def.DataDef.Type, nil
+
+	selectType := senseobjdef.SelectTypeUnknown
+	selectPath := ""
+
+	if def.Select != nil {
+		selectPath = def.Select.Path
+		selectType = def.Select.Type
+	}
+
+	return selectPath, selectType, def.DataDef.Type, nil
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

avoid nilpointer exception when using objects without select definitions in select action
