### PR TITLE
avoid nilpointer panic in jwtconnection validation

### DIFF
--- a/connection/jwtconnection.go
+++ b/connection/jwtconnection.go
@@ -92,6 +92,10 @@ func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State
 
 // Validate connectJWTSettings
 func (connectJWT *ConnectJWTSettings) Validate() error {
+	if connectJWT == nil {
+		return errors.New("no JWT settings defined")
+	}
+
 	// Do we have a key? (if so, also read into memory)
 	key, err := connectJWT.getPrivateKey()
 	if err != nil {


### PR DESCRIPTION
Having `"mode":"jwt"` without any settings for JWT connection resulted in panic:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9b122f]

goroutine 1 [running]:
...
```

Now gives the following error

```JSONValidateError: ConnectionSettings validation failed: no JWT settings defined```


**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

Avoid nil pointer panic in jwtconnection validation
