### PR TITLE
Don't rename action on reconnected action of type thinktime

### DIFF
--- a/scenario/actionhandler.go
+++ b/scenario/actionhandler.go
@@ -394,7 +394,7 @@ func (act *Action) execute(sessionState *session.State, connectionSettings *conn
 
 				// rename action and label if we had a reconnect
 				switch act.Settings.(type) {
-				case ThinkTimeSettings:
+				case ThinkTimeSettings, *ThinkTimeSettings:
 					// Don't rename action if it's a thinktime to not affect analyzer results
 				default:
 					sessionState.LogEntry.Action.Action = fmt.Sprintf("Reconnect(%s)", sessionState.LogEntry.Action.Action)


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

Don't rename action on reconnected action of type thinktime, also when the settings are a pointer.
