### PR TITLE
Log elastic reload duration consistently as milliseconds

### DIFF
--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -167,5 +167,10 @@ func (settings ElasticReloadSettings) Execute(sessionState *session.State, actio
 	if settings.ElasticReloadCore.SaveLog {
 		sessionState.LogEntry.LogInfo("ReloadLog", log)
 	}
-	sessionState.LogEntry.LogInfo("ReloadDuration", reloadTime)
+
+	if duration, err := time.ParseDuration(reloadTime); err != nil || reloadTime == "" {
+		sessionState.LogEntry.LogInfo("ReloadDuration", reloadTime)
+	} else {
+		sessionState.LogEntry.LogInfo("ReloadDuration", fmt.Sprintf("%dms", duration.Milliseconds()))
+	}
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

Log elastic reload duration consistently as milliseconds to make it easier to parse by analyzer.
