### PR TITLE
Apicompliance/617 Elasticexplore changes

### DIFF
--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -1602,7 +1602,7 @@ Explore the hub for apps and fill the artifact map with apps to be used by other
 ### Settings
 
 * `keepcurrent`: Keep the current artifact map and add the results from the `elasticexplore` action. Defaults to `false` (that is, empty the artifact map before adding the results from the `elasticexplore` action), if omitted.
-* `paging`: Go through all app pages in the hub. Defaults to `false` (that is, only include the first 24 apps that the user can see), if omitted.
+* `paging`: Go through all app pages in the hub. Defaults to `false` (that is, only include the first 30 apps that the user can see), if omitted.
 * `sorting`: Simulate selecting sort order in the drop-down menu in the hub
     * `default`: Default sort order (`created`).
     * `created`: Sort by the time of creation.

--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -1602,7 +1602,7 @@ Explore the hub for apps and fill the artifact map with apps to be used by other
 ### Settings
 
 * `keepcurrent`: Keep the current artifact map and add the results from the `elasticexplore` action. Defaults to `false` (that is, empty the artifact map before adding the results from the `elasticexplore` action), if omitted.
-* `paging`: Go through all app pages in the hub. Defaults to `false` (that is, only include the first 30 apps that the user can see), if omitted.
+* `paging`: Go through all app pages in the hub. Defaults to `false` (that is, only include the first 24 apps that the user can see), if omitted.
 * `sorting`: Simulate selecting sort order in the drop-down menu in the hub
     * `default`: Default sort order (`created`).
     * `created`: Sort by the time of creation.

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -320,7 +320,7 @@
         "Keep the current artifact map and add the results from the `elasticexplore` action. Defaults to `false` (that is, empty the artifact map before adding the results from the `elasticexplore` action), if omitted."
     ],
     "elasticexplore.paging": [
-        "Go through all app pages in the hub. Defaults to `false` (that is, only include the first 30 apps that the user can see), if omitted."
+        "Go through all app pages in the hub. Defaults to `false` (that is, only include the first 24 apps that the user can see), if omitted."
     ],
     "elasticexplore.sorting": [
         "Simulate selecting sort order in the drop-down menu in the hub",

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -286,7 +286,7 @@ var (
         "elasticduplicateapp.spaceid": { "(optional) GUID of the shared space in which to publish the app."  },  
         "elasticexplore.keepcurrent": { "Keep the current artifact map and add the results from the `elasticexplore` action. Defaults to `false` (that is, empty the artifact map before adding the results from the `elasticexplore` action), if omitted."  },  
         "elasticexplore.owner": { "Filter apps by owner","`all`: Apps owned by anyone.","`me`: Apps owned by the simulated user.","`others`: Apps not owned by the simulated user."  },  
-        "elasticexplore.paging": { "Go through all app pages in the hub. Defaults to `false` (that is, only include the first 30 apps that the user can see), if omitted."  },  
+        "elasticexplore.paging": { "Go through all app pages in the hub. Defaults to `false` (that is, only include the first 24 apps that the user can see), if omitted."  },  
         "elasticexplore.sorting": { "Simulate selecting sort order in the drop-down menu in the hub","`default`: Default sort order (`created`).","`created`: Sort by the time of creation.","`updated`: Sort by the time of modification.","`name`: Sort by name."  },  
         "elasticexplore.space": { "Filter apps by space name (supports the use of [session variables](#session_variables)). **Note:** This filter cannot be used together with `spaceid`."  },  
         "elasticexplore.spaceid": { "Filter apps by space GUID. **Note:** This filter cannot be used together with `space`."  },  

--- a/scenario/elasticexplore.go
+++ b/scenario/elasticexplore.go
@@ -195,7 +195,7 @@ func (settings ElasticExploreSettings) Execute(sessionState *session.State, acti
 	// Was tags dropdown "clicked"?
 	if collectionCount > 0 {
 		collectionIds := make([]string, 0, collectionCount)
-		sessionState.Rest.GetAsyncWithCallback(fmt.Sprintf("%s/api/v1/collections?type=public&sort=-updatedAt", host), actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
+		sessionState.Rest.GetAsyncWithCallback(fmt.Sprintf("%s/api/v1/collections?type=public&sort=-name&limit=100", host), actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
 			var collectionData elasticstructs.CollectionRequest
 			if err := jsonit.Unmarshal(req.ResponseBody, &collectionData); err != nil {
 				actionState.AddErrors(errors.Wrap(err, "failed unmarshaling collection data"))
@@ -251,7 +251,7 @@ func (settings ElasticExploreSettings) Execute(sessionState *session.State, acti
 	}
 
 	// apply per page limit
-	urlParams["limit"] = "30"
+	urlParams["limit"] = "24"
 
 	// apply sorting
 	urlParams["sort"] = settings.Sorting.Value()


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [x] documentation updated

**Squash commit message**

Updated both elasticexplore action API from limit=30 to limit=24 to reflect the current statue in QCS.  Also updated the API call change when tag drop down is selected (only seen when the tag parameter is provided in scenario and thus filter by collectionID)