### PR TITLE
only trigger timebuffer.wait(errors==true) if there was an error

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -229,12 +229,12 @@ func (sched *Scheduler) runIteration(userScenario []scenario.Action, sessionStat
 		if isAborted, _ := scenario.CheckActionError(err); isAborted {
 			return nil
 		}
-		if errTimeBuf := sched.TimeBuf.Wait(ctx, true); errTimeBuf != nil {
-			logEntry := sessionState.LogEntry.ShallowCopy()
-			logEntry.Action = nil
-			logEntry.LogError(errors.Wrap(errTimeBuf, "time buffer in-between sequences failed"))
-		}
 		if err != nil {
+			if errTimeBuf := sched.TimeBuf.Wait(ctx, true); errTimeBuf != nil {
+				logEntry := sessionState.LogEntry.ShallowCopy()
+				logEntry.Action = nil
+				logEntry.LogError(errors.Wrap(errTimeBuf, "time buffer in-between sequences failed"))
+			}
 			return errors.WithStack(err)
 		}
 	}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [ ] documentation updated

**Squash commit message**

Bugfix: If timebuffer `onerror` was set it would wait inbetween each action (bug introduced in re-connect logic merge, not affecting any released versions).
