### PR TITLE
Add and use an enum constructor with panic

### DIFF
--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -2,6 +2,7 @@ package appstructure
 
 import (
 	"encoding/json"
+
 	"github.com/qlik-oss/gopherciser/enummap"
 )
 
@@ -134,7 +135,7 @@ const (
 )
 
 var (
-	ObjectTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+	ObjectTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"dimension":    int(ObjectTypeDimension),
 		"measure":      int(ObjectTypeMeasure),
 		"bookmark":     int(ObjectTypeBookmark),

--- a/enummap/enummap.go
+++ b/enummap/enummap.go
@@ -59,7 +59,7 @@ func New() *EnumMap {
 	return em
 }
 
-// NewEnumMap new enum map from map. Returns error if duplicate values and
+// NewEnumMap new enum map from map. Returns error if duplicate values or
 // non-lowercase keys. NewEnumMapOrPanic is preferable for global
 // EnumMap-variables.
 func NewEnumMap(m map[string]int) (*EnumMap, error) {

--- a/enummap/enummap.go
+++ b/enummap/enummap.go
@@ -59,7 +59,9 @@ func New() *EnumMap {
 	return em
 }
 
-// NewEnumMap new enum map from map
+// NewEnumMap new enum map from map. Returns error if duplicate values and
+// non-lowercase keys. NewEnumMapOrPanic is preferable for global
+// EnumMap-variables.
 func NewEnumMap(m map[string]int) (*EnumMap, error) {
 	em := &EnumMap{
 		asInt: m,
@@ -82,6 +84,20 @@ func NewEnumMap(m map[string]int) (*EnumMap, error) {
 	return em, nil
 }
 
+// NewEnumMapOrPanic is intended for assignment to global EnumMap-variables,
+// within global scope or init()-function. When used for global variables
+// NewEnumMapOrPanic fails early, which will be detected by any tests in the
+// same package (even with an empty test file). NewEnumMap is preferable in
+// other cases.
+func NewEnumMapOrPanic(m map[string]int) *EnumMap {
+	enumMap, err := NewEnumMap(m)
+	if err != nil {
+		panic(fmt.Errorf("Invalid EnumMap: %s", err))
+	}
+	return enumMap
+}
+
+// AsInt returns string to integer map representation of EnumMap
 func (em *EnumMap) AsInt() map[string]int {
 	return em.asInt
 }

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -37,7 +37,7 @@ const (
 
 var (
 	// ProfileTypeEnum enum of profiling options
-	ProfileTypeEnum, _ = enummap.NewEnumMap(map[string]int{
+	ProfileTypeEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"cpu":          int(ProfileTypeCPU),
 		"block":        int(ProfileTypeBlock),
 		"goroutine":    int(ProfileTypeGoRoutine),

--- a/scenario/elasticdeleteapp.go
+++ b/scenario/elasticdeleteapp.go
@@ -46,7 +46,7 @@ const (
 	ClearCollection
 )
 
-var deletionModeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+var deletionModeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 	"single":          int(Single),
 	"everything":      int(Everything),
 	"clearcollection": int(ClearCollection),

--- a/scenario/elasticexplore.go
+++ b/scenario/elasticexplore.go
@@ -57,14 +57,14 @@ const (
 )
 
 var (
-	sortingEnum, _ = enummap.NewEnumMap(map[string]int{
+	sortingEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"default": int(SortingModeDefault),
 		"created": int(SortingModeCreatedAt),
 		"updated": int(SortingModeUpdatedAt),
 		"name":    int(SortingModeName),
 	})
 
-	ownerEnum, _ = enummap.NewEnumMap(map[string]int{
+	ownerEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"all":    int(OwnerModeAll),
 		"me":     int(OwnerModeMe),
 		"others": int(OwnerModeOthers),

--- a/scenario/listboxselect.go
+++ b/scenario/listboxselect.go
@@ -41,7 +41,7 @@ const (
 	Excluded
 )
 
-var listBoxSelectTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+var listBoxSelectTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 	"all":         int(All),
 	"possible":    int(Possible),
 	"alternative": int(Alternative),

--- a/scenario/publishsheet.go
+++ b/scenario/publishsheet.go
@@ -30,12 +30,12 @@ const (
 	SheetIDs
 )
 
-var publishSheetModeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+var publishSheetModeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 	"allsheets": int(AllSheets),
 	"sheetids":  int(SheetIDs),
 })
 
-func (value PublishSheetMode) GetEnumMap() *enummap.EnumMap{
+func (value PublishSheetMode) GetEnumMap() *enummap.EnumMap {
 	return publishSheetModeEnumMap
 }
 

--- a/scenario/randomaction.go
+++ b/scenario/randomaction.go
@@ -66,7 +66,7 @@ const (
 )
 
 var (
-	actionTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+	actionTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"thinktime":            int(ThinkTime),
 		"sheetobjectselection": int(SheetObjectSelection),
 		"changesheet":          int(ChangeSheet),

--- a/scenario/select.go
+++ b/scenario/select.go
@@ -66,7 +66,7 @@ const (
 	selectStateExcludedLocked
 )
 
-var selectionTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+var selectionTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 	"randomfromall":      int(RandomFromAll),
 	"randomfromenabled":  int(RandomFromEnabled),
 	"randomfromexcluded": int(RandomFromExcluded),
@@ -78,7 +78,7 @@ func (value SelectionType) GetEnumMap() *enummap.EnumMap {
 }
 
 var (
-	selectStateHandler, _ = enummap.NewEnumMap(map[string]int{
+	selectStateHandler = enummap.NewEnumMapOrPanic(map[string]int{
 		"l":  int(selectStateLocked),
 		"s":  int(selectStateSelected),
 		"o":  int(selectStateOption),

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -68,7 +68,7 @@ const (
 )
 
 var (
-	schedulerTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+	schedulerTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"simple": int(SchedSimple),
 	})
 )

--- a/senseobjdef/constraint.go
+++ b/senseobjdef/constraint.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	constraintOperatorEnum, _ = enummap.NewEnumMap(map[string]int{
+	constraintOperatorEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"<": int(lessThanOperator),
 		">": int(largerThanOperator),
 		"=": int(equalOperator),

--- a/senseobjdef/senseobjdef.go
+++ b/senseobjdef/senseobjdef.go
@@ -125,21 +125,21 @@ const (
 var (
 	od ObjectDefs
 
-	dataDefTypeEnum, _ = enummap.NewEnumMap(map[string]int{
+	dataDefTypeEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"unknown":    int(DataDefUnknown),
 		"listobject": int(DataDefListObject),
 		"hypercube":  int(DataDefHyperCube),
 		"nodata":     int(DataDefNoData),
 	})
 
-	selectTypeEnum, _ = enummap.NewEnumMap(map[string]int{
+	selectTypeEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"unknown":               int(SelectTypeUnknown),
 		"listobjectvalues":      int(SelectTypeListObjectValues),
 		"hypercubevalues":       int(SelectTypeHypercubeValues),
 		"hypercubecolumnvalues": int(SelectTypeHypercubeColumnValues),
 	})
 
-	dataTypeEnum, _ = enummap.NewEnumMap(map[string]int{
+	dataTypeEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"layout":                  int(DataTypeLayout),
 		"listobjectdata":          int(DataTypeListObject),
 		"hypercubedata":           int(DataTypeHyperCubeData),

--- a/session/appselection.go
+++ b/session/appselection.go
@@ -35,7 +35,7 @@ type (
 )
 
 var (
-	appModeEnum, _ = enummap.NewEnumMap(map[string]int{
+	appModeEnum = enummap.NewEnumMapOrPanic(map[string]int{
 		"current":            int(AppModeCurrent),
 		"guid":               int(AppModeGUID),
 		"name":               int(AppModeName),

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -98,7 +98,7 @@ const (
 )
 
 var (
-	restMethodEnumMap, _ = enummap.NewEnumMap(map[string]int{
+	restMethodEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"get":    int(GET),
 		"post":   int(POST),
 		"delete": int(DELETE),

--- a/users/usergenerator.go
+++ b/users/usergenerator.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/qlik-oss/gopherciser/statistics"
-
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/enummap"
+	"github.com/qlik-oss/gopherciser/statistics"
 )
 
 type (

--- a/users/usergenerator.go
+++ b/users/usergenerator.go
@@ -3,8 +3,9 @@ package users
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qlik-oss/gopherciser/statistics"
 	"runtime"
+
+	"github.com/qlik-oss/gopherciser/statistics"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
@@ -51,7 +52,7 @@ const (
 )
 
 var (
-	userGeneratorTypeEnumMap, _ = enummap.NewEnumMap(map[string]int{
+	userGeneratorTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"userlist": int(UserGeneratorCircular),
 		"prefix":   int(UserGeneratorPrefix),
 		"none":     int(UserGeneratorNone),


### PR DESCRIPTION
Errors returned by the other constructor tended to be ignored when
initializing global variables. When passing an invalid map to the
constructor, early panics are preferable to nil pointer dereferences
later during execution.

**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [x] documentation updated

**Squash commit message**

Descriptive text which can be used on the squash commit message to master.
