### PR TITLE
Add info section to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
 **Checklist**
 
 - [ ] tests added
-- [ ] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
+- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
 - [ ] documentation updated
+
 
 **Squash commit message**
 
-Descriptive text which can be used on the squash commit message to master.
+Descriptive text which shall be used as squash commit message to master.
+
+**Info**
+
+Optional informative text (not to be included in commit message) relevant to reviewers.


### PR DESCRIPTION
This is done to keep squash commit message clean, which makes it easier
to review.

Also:
* Absolute link to commit message format convention

**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](./CONTRIBUTING.md#commit)
- [x] documentation updated

**Squash commit message**

Add info section to pull request template

This is done to keep squash commit message clean, which makes it easier to review.

**Info**

When on it, I changed the link to commit message format conventions to an absolute link. The generated link was the wrong one in this message.

The descriptive text for squash commit message was also reworded to encourage commit message to be a part of the review process.