### PR TITLE
Make qID fetch in elasticopenhub optional

### DIFF
--- a/scenario/deletedata.go
+++ b/scenario/deletedata.go
@@ -48,7 +48,7 @@ func (settings DeleteDataSettings) Execute(
 	restHandler := sessionState.Rest
 
 	if sessionState.DataConnectionId == "" {
-		FetchQid(sessionState, actionState, host, true)
+		FetchDataConnectionId(sessionState, actionState, host, true)
 		if sessionState.Wait(actionState) {
 			return // we had an error
 		}

--- a/scenario/deletedata.go
+++ b/scenario/deletedata.go
@@ -47,6 +47,13 @@ func (settings DeleteDataSettings) Execute(
 
 	restHandler := sessionState.Rest
 
+	if sessionState.DataConnectionId == "" {
+		FetchQid(sessionState, actionState, host, true)
+		if sessionState.Wait(actionState) {
+			return // we had an error
+		}
+	}
+
 	// Look up the database ID for the file GUID
 	getItems := session.RestRequest{
 		Method:      session.GET,

--- a/scenario/elasticopenhub.go
+++ b/scenario/elasticopenhub.go
@@ -208,7 +208,7 @@ func (openHub ElasticOpenHubSettings) Execute(sessionState *session.State, actio
 	sessionState.Rest.GetAsync(fmt.Sprintf("%s/api/v1/subscriptions", host), actionState, sessionState.LogEntry, nil)
 	sessionState.Rest.GetAsync(fmt.Sprintf("%s/api/v1/qix-datafiles/quota", host), actionState, sessionState.LogEntry, nil)
 
-	FetchQid(sessionState, actionState, host, false)
+	FetchDataConnectionId(sessionState, actionState, host, false)
 
 	sessionState.Rest.GetAsyncWithCallback(fmt.Sprintf("%s/api/v1/items?sort=-createdAt&limit=24&ownerId=%s", host, userData.ID), actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
 		fillAppMapFromItemRequest(sessionState, actionState, req, false)

--- a/scenario/elasticopenhub.go
+++ b/scenario/elasticopenhub.go
@@ -208,30 +208,7 @@ func (openHub ElasticOpenHubSettings) Execute(sessionState *session.State, actio
 	sessionState.Rest.GetAsync(fmt.Sprintf("%s/api/v1/subscriptions", host), actionState, sessionState.LogEntry, nil)
 	sessionState.Rest.GetAsync(fmt.Sprintf("%s/api/v1/qix-datafiles/quota", host), actionState, sessionState.LogEntry, nil)
 
-	sessionState.Rest.GetAsyncWithCallback(fmt.Sprintf("%s/api/v1/dc-dataconnections?alldatafiles=true&allspaces=true&personal=true&owner=default&extended=true", host), actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
-		var datafilesResp elasticstructs.DataFilesResp
-		var qID string
-		var qName = "DataFiles"
-		if err := jsonit.Unmarshal(req.ResponseBody, &datafilesResp); err != nil {
-			actionState.AddErrors(errors.Wrap(err, "failed unmarshaling dataconnections data"))
-			return
-		}
-		for _, datafilesresp := range datafilesResp.Data {
-			if datafilesresp.QName == qName && datafilesresp.Space == "" {
-				qID = datafilesresp.QID
-				break
-			}
-
-		}
-
-		if qID == "" {
-			actionState.AddErrors(errors.Errorf("failed to find qID in dataconnections for <%s>", qName))
-		} else {
-			sessionState.DataConnectionId = qID
-			sessionState.Rest.GetAsync(fmt.Sprintf("%s/api/v1/qix-datafiles?top=1000&connectionId=%s", host, qID), actionState, sessionState.LogEntry, nil)
-		}
-
-	})
+	FetchQid(sessionState, actionState, host, false)
 
 	sessionState.Rest.GetAsyncWithCallback(fmt.Sprintf("%s/api/v1/items?sort=-createdAt&limit=24&ownerId=%s", host, userData.ID), actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
 		fillAppMapFromItemRequest(sessionState, actionState, req, false)

--- a/scenario/uploaddata.go
+++ b/scenario/uploaddata.go
@@ -161,14 +161,18 @@ func (settings UploadDataSettings) Execute(
 
 func FetchDataConnectionId(sessionState *session.State, actionState *action.State, host string, userSpecific bool) *session.RestRequest {
 	endpoint := fmt.Sprintf("%s/api/v1/dc-dataconnections?alldatafiles=true&allspaces=true&personal=true&owner=default&extended=true", host)
+	var opts *session.ReqOptions
 	if userSpecific {
 		endpoint = fmt.Sprintf(
 			"%s/api/v1/dc-dataconnections?owner=%s&personal=true&alldatafiles=true&allspaces=true", host,
 			sessionState.CurrentUser.ID,
 		)
+	} else {
+		opts = &session.ReqOptions{FailOnError: false}
 	}
+
 	return sessionState.Rest.GetAsyncWithCallback(
-		endpoint, actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
+		endpoint, actionState, sessionState.LogEntry, opts, func(err error, req *session.RestRequest) {
 			var datafilesResp elasticstructs.DataFilesResp
 			var qID string
 			var qName = "DataFiles"

--- a/scenario/uploaddata.go
+++ b/scenario/uploaddata.go
@@ -55,7 +55,7 @@ func (settings UploadDataSettings) Execute(
 	restHandler := sessionState.Rest
 
 	if sessionState.DataConnectionId == "" {
-		FetchQid(sessionState, actionState, host, true)
+		FetchDataConnectionId(sessionState, actionState, host, true)
 		if sessionState.Wait(actionState) {
 			return // we had an error
 		}
@@ -159,7 +159,7 @@ func (settings UploadDataSettings) Execute(
 	}
 }
 
-func FetchQid(sessionState *session.State, actionState *action.State, host string, userSpecific bool) *session.RestRequest {
+func FetchDataConnectionId(sessionState *session.State, actionState *action.State, host string, userSpecific bool) *session.RestRequest {
 	endpoint := fmt.Sprintf("%s/api/v1/dc-dataconnections?alldatafiles=true&allspaces=true&personal=true&owner=default&extended=true", host)
 	if userSpecific {
 		endpoint = fmt.Sprintf(

--- a/scenario/uploaddata.go
+++ b/scenario/uploaddata.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"bytes"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/elasticstructs"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -52,6 +53,13 @@ func (settings UploadDataSettings) Execute(
 	}
 
 	restHandler := sessionState.Rest
+
+	if sessionState.DataConnectionId == "" {
+		FetchQid(sessionState, actionState, host, true)
+		if sessionState.Wait(actionState) {
+			return // we had an error
+		}
+	}
 
 	file, err := os.Open(settings.Filename)
 	if err != nil {
@@ -149,4 +157,51 @@ func (settings UploadDataSettings) Execute(
 	if sessionState.Wait(actionState) {
 		return // we had an error
 	}
+}
+
+func FetchQid(sessionState *session.State, actionState *action.State, host string, userSpecific bool) *session.RestRequest {
+	endpoint := fmt.Sprintf("%s/api/v1/dc-dataconnections?alldatafiles=true&allspaces=true&personal=true&owner=default&extended=true", host)
+	if userSpecific {
+		endpoint = fmt.Sprintf(
+			"%s/api/v1/dc-dataconnections?owner=%s&personal=true&alldatafiles=true&allspaces=true", host,
+			sessionState.CurrentUser.ID,
+		)
+	}
+	return sessionState.Rest.GetAsyncWithCallback(
+		endpoint, actionState, sessionState.LogEntry, nil, func(err error, req *session.RestRequest) {
+			var datafilesResp elasticstructs.DataFilesResp
+			var qID string
+			var qName = "DataFiles"
+			if err := jsonit.Unmarshal(req.ResponseBody, &datafilesResp); err != nil {
+				actionState.AddErrors(errors.Wrap(err, "failed unmarshaling dataconnections data"))
+				return
+			}
+			for _, datafilesresp := range datafilesResp.Data {
+				if datafilesresp.QName == qName && datafilesresp.Space == "" {
+					qID = datafilesresp.QID
+					break
+				}
+
+			}
+
+			if qID == "" {
+				if userSpecific {
+					actionState.AddErrors(
+						errors.Errorf(
+							"failed to find qID for <%s> in dataconnections for user <%s>", qName,
+							sessionState.CurrentUser.ID,
+						),
+					)
+				} else {
+					sessionState.LogEntry.Log(logger.WarningLevel, fmt.Sprintf("failed to find qID in dataconnections for <%s>", qName))
+				}
+			} else {
+				sessionState.DataConnectionId = qID
+				sessionState.Rest.GetAsync(
+					fmt.Sprintf("%s/api/v1/qix-datafiles?top=1000&connectionId=%s", host, qID), actionState,
+					sessionState.LogEntry, nil,
+				)
+			}
+		},
+	)
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

If no connection ID is returned in ElasticOpenHub, throw a warning rather than an error. Instead, retry the fetch when doing an upload or deleting a file (client does this upon entering DLE). An error will still be thrown if it fails at this point.
