### PR TITLE
make sure not to include port when looking up header

### DIFF
--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -15,7 +15,7 @@ type (
 )
 
 // GetConnectFunc get ws connect function
-func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID string, header http.Header) func() (string, error) {
+func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID string, header http.Header) func() (string, error) {
 	return func() (string, error) {
 		if sessionState == nil {
 			return appGUID, errors.New("Session state is nil")
@@ -31,7 +31,7 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 		sessionState.Connection.SetSense(sense)
 		sense.OnUnexpectedDisconnect(sessionState.WSFailed)
 
-		url, err := connection.GetURL(appGUID)
+		url, err := connectionSettings.GetURL(appGUID)
 		if err != nil {
 			return appGUID, errors.WithStack(err)
 		}
@@ -43,9 +43,10 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 			}
 		}
 
-		if err := sense.Connect(sessionState.BaseContext(), url, header, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout); err != nil {
+		if err := sense.Connect(sessionState.BaseContext(), url, header, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
 			return appGUID, errors.Wrap(err, "Failed connecting to sense server")
 		}
+
 		return appGUID, nil
 	}
 }

--- a/scenario/openapp.go
+++ b/scenario/openapp.go
@@ -3,13 +3,14 @@ package scenario
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/action"
 	"github.com/qlik-oss/gopherciser/appstructure"
 	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/enigmahandlers"
 	"github.com/qlik-oss/gopherciser/session"
-	"strings"
 )
 
 type (
@@ -232,7 +233,7 @@ func (openApp OpenAppSettings) AppStructureAction() (*AppStructureInfo, []Action
 	}, nil
 }
 
-func (connectWs connectWsSettings) Execute(sessionState *session.State, actionState *action.State, connection *connection.ConnectionSettings, label string, reset func()) {
+func (connectWs connectWsSettings) Execute(sessionState *session.State, actionState *action.State, connectionSettings *connection.ConnectionSettings, label string, reset func()) {
 	appGUID, err := connectWs.ConnectFunc()
 	if err != nil {
 		actionState.AddErrors(errors.Wrap(err, "Failed connecting to sense server"))

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -872,7 +872,7 @@ func (state *State) SetupEventWebsocketAsync(actionState *action.State, nurl net
 		metricslogger := &EventMetricsLogger{LogEntry: state.LogEntry}
 		var err error
 		state.eventWs, err = eventws.SetupEventSocket(ctx, state.BaseContext(), state.Timeout, state.Cookies, state.trafficLogger, metricslogger, &nurl,
-			state.HeaderJar.GetHeader(nurl.Host), allowuntrusted, state.RequestMetrics, currentActionState)
+			state.HeaderJar.GetHeader(nurl.Hostname()), allowuntrusted, state.RequestMetrics, currentActionState)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/wsdialer/wsdialer.go
+++ b/wsdialer/wsdialer.go
@@ -77,8 +77,13 @@ func New(url *neturl.URL, httpHeader http.Header, cookieJar http.CookieJar, time
 	if timeout.Nanoseconds() < 1 {
 		timeout = DefaultTimeout
 	}
+	var wsHeader http.Header
+	if httpHeader == nil {
+		wsHeader = make(http.Header)
+	} else {
+		wsHeader = httpHeader.Clone()
+	}
 
-	wsHeader := httpHeader.Clone()
 	// cookie needs to be set using http not ws scheme
 	cookieUrl := *url
 	if cookieJar != nil {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Use hostname without port when looking up header

**Info**
bugfix is the change in  `session/sessionstate.go` the rest is minor refactoring I left in.

