### PR TITLE
Enhancement/644 add story objects to app structure

### DIFF
--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -51,18 +51,23 @@ type (
 		Labels []string `json:"labels,omitempty"`
 	}
 
+	// AppStructureObjectChildren substructure adding children
+	AppStructureObjectChildren struct{
+		// Children to the sense object
+		Children map[string]string `json:"children,omitempty"`
+	}
+
 	// AppStructureObject sense object structure
 	AppStructureObject struct {
 		AppObjectDef
 		MetaDef
+		AppStructureObjectChildren
 		// RawBaseProperties of Sense object
 		RawBaseProperties json.RawMessage `json:"rawBaseProperties,omitempty"`
 		// RawExtendedProperties of extended Sense object
 		RawExtendedProperties json.RawMessage `json:"rawExtendedProperties,omitempty"`
 		// RawGeneratedProperties inner generated properties of auto-chart
 		RawGeneratedProperties json.RawMessage `json:"rawGeneratedProperties,omitempty"`
-		// Children to the sense object
-		Children map[string]string `json:"children,omitempty"`
 		// Selectable true if select can be done in object
 		Selectable bool `json:"selectable"`
 		// Dimensions meta information of dimensions defined in object
@@ -99,8 +104,14 @@ type (
 		RawProperties json.RawMessage `json:"rawProperties,omitempty"`
 	}
 
+	// AppStructureStoryObject list of objects used in stories
 	AppStructureStoryObject struct {
 		AppObjectDef
+		AppStructureObjectChildren
+		// RawProperties of Sense object
+		RawProperties json.RawMessage `json:"rawProperties,omitempty"`
+		// Visualization visualization of object, if exists
+		Visualization string `json:"visualization,omitempty"`
 	}
 
 	// AppStructureField list of fields in the app

--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -53,8 +53,8 @@ type (
 
 	// AppStructureObjectChildren substructure adding children
 	AppStructureObjectChildren struct {
-		// Children to the sense object
-		Children map[string]string `json:"children,omitempty"`
+		// Map of children to the sense object
+		Map map[string]string `json:"children,omitempty"`
 	}
 
 	// AppStructureObject sense object structure
@@ -217,7 +217,7 @@ func (structure *AppStructure) addSelectableChildren(obj AppStructureObject) []A
 		selectables = append(selectables, obj)
 	}
 
-	for id := range obj.Children {
+	for id := range obj.Map {
 		child, ok := structure.Objects[id]
 		if !ok {
 			continue

--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -52,7 +52,7 @@ type (
 	}
 
 	// AppStructureObjectChildren substructure adding children
-	AppStructureObjectChildren struct{
+	AppStructureObjectChildren struct {
 		// Children to the sense object
 		Children map[string]string `json:"children,omitempty"`
 	}
@@ -159,18 +159,16 @@ const (
 	ObjectAppprops
 
 	// Objects connected to snapshots and stories
-	ObjectSnapshot
 	ObjectSnapshotList
+	ObjectSnapshot
 	ObjectEmbeddedSnapshot
+	ObjectStory
 	ObjectSlide
 	ObjectSlideItem
-	ObjectImage
-	ObjectStory
-	ObjectText
-	ObjectShape
 )
 
 var (
+	// ObjectTypeEnumMap enum of known object types which needs special handling
 	ObjectTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
 		"dimension":        int(ObjectTypeDimension),
 		"measure":          int(ObjectTypeMeasure),
@@ -180,15 +178,12 @@ var (
 		"sheet":            int(ObjectSheet),
 		"loadmodel":        int(ObjectLoadModel),
 		"appprops":         int(ObjectAppprops),
-		"snapshot":         int(ObjectSnapshot),
 		"snapshotlist":     int(ObjectSnapshotList),
+		"snapshot":         int(ObjectSnapshot),
 		"embeddedsnapshot": int(ObjectEmbeddedSnapshot),
+		"story":            int(ObjectStory),
 		"slide":            int(ObjectSlide),
 		"slideitem":        int(ObjectSlideItem),
-		"image":            int(ObjectImage),
-		"story":            int(ObjectStory),
-		"text":             int(ObjectText),
-		"shape":            int(ObjectShape),
 	})
 )
 

--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -112,6 +112,10 @@ type (
 		RawProperties json.RawMessage `json:"rawProperties,omitempty"`
 		// Visualization visualization of object, if exists
 		Visualization string `json:"visualization,omitempty"`
+		// SnapshotID of linked object snapshot object
+		SnapshotID string `json:"snapshotid,omitempty"`
+		// RawSnapShotProperties of extended snapshot object
+		RawSnapShotProperties json.RawMessage `json:"rawSnapshotProperties,omitempty"`
 	}
 
 	// AppStructureField list of fields in the app

--- a/appstructure/appstructure.go
+++ b/appstructure/appstructure.go
@@ -99,6 +99,10 @@ type (
 		RawProperties json.RawMessage `json:"rawProperties,omitempty"`
 	}
 
+	AppStructureStoryObject struct {
+		AppObjectDef
+	}
+
 	// AppStructureField list of fields in the app
 	AppStructureField struct {
 		enigma.NxFieldDescription
@@ -113,6 +117,8 @@ type (
 		Bookmarks map[string]AppStructureBookmark `json:"bookmarks"`
 		// Fields list of all fields in the app
 		Fields map[string]AppStructureField `json:"fields"`
+		// StoryObjects
+		StoryObjects map[string]AppStructureStoryObject `json:"storyobjects"`
 	}
 
 	// AppStructurePopulatedObjects is the type returned by an action when prompted for selectable objects
@@ -140,22 +146,38 @@ const (
 	ObjectSheet
 	ObjectLoadModel
 	ObjectAppprops
+
+	// Objects connected to snapshots and stories
 	ObjectSnapshot
 	ObjectSnapshotList
+	ObjectEmbeddedSnapshot
+	ObjectSlide
+	ObjectSlideItem
+	ObjectImage
+	ObjectStory
+	ObjectText
+	ObjectShape
 )
 
 var (
 	ObjectTypeEnumMap = enummap.NewEnumMapOrPanic(map[string]int{
-		"dimension":    int(ObjectTypeDimension),
-		"measure":      int(ObjectTypeMeasure),
-		"bookmark":     int(ObjectTypeBookmark),
-		"masterobject": int(ObjectTypeMasterObject),
-		"auto-chart":   int(ObjectTypeAutoChart),
-		"sheet":        int(ObjectSheet),
-		"loadmodel":    int(ObjectLoadModel),
-		"appprops":     int(ObjectAppprops),
-		"snapshot":     int(ObjectSnapshot),
-		"snapshotlist": int(ObjectSnapshotList),
+		"dimension":        int(ObjectTypeDimension),
+		"measure":          int(ObjectTypeMeasure),
+		"bookmark":         int(ObjectTypeBookmark),
+		"masterobject":     int(ObjectTypeMasterObject),
+		"auto-chart":       int(ObjectTypeAutoChart),
+		"sheet":            int(ObjectSheet),
+		"loadmodel":        int(ObjectLoadModel),
+		"appprops":         int(ObjectAppprops),
+		"snapshot":         int(ObjectSnapshot),
+		"snapshotlist":     int(ObjectSnapshotList),
+		"embeddedsnapshot": int(ObjectEmbeddedSnapshot),
+		"slide":            int(ObjectSlide),
+		"slideitem":        int(ObjectSlideItem),
+		"image":            int(ObjectImage),
+		"story":            int(ObjectStory),
+		"text":             int(ObjectText),
+		"shape":            int(ObjectShape),
 	})
 )
 

--- a/config/appstructure.go
+++ b/config/appstructure.go
@@ -393,7 +393,7 @@ func extractGeneratedProperties(properties json.RawMessage) json.RawMessage {
 	return properties
 }
 
-func handleChildren(ctx context.Context, genObj *enigma.GenericObject, obj *appstructure.AppStructureObjectChildren) error {
+func handleChildren(ctx context.Context, genObj *enigma.GenericObject, children *appstructure.AppStructureObjectChildren) error {
 	childInfos, err := genObj.GetChildInfos(ctx)
 	if err != nil {
 		return errors.WithStack(err)
@@ -403,10 +403,10 @@ func handleChildren(ctx context.Context, genObj *enigma.GenericObject, obj *apps
 		if child == nil {
 			continue
 		}
-		if obj.Children == nil {
-			obj.Children = make(map[string]string)
+		if children.Map == nil {
+			children.Map = make(map[string]string)
 		}
-		obj.Children[child.Id] = child.Type
+		children.Map[child.Id] = child.Type
 	}
 
 	return nil

--- a/config/appstructure.go
+++ b/config/appstructure.go
@@ -702,7 +702,7 @@ func (structure *GeneratedAppStructure) handleStories(ctx context.Context, app *
 		return
 	}
 
-	if storyObject.Visualization == "snapshot" {
+	if storyObject.Visualization == appstructure.ObjectTypeEnumMap.StringDefault(int(appstructure.ObjectSnapshot), "snapshot") {
 		snapShotObj, err := obj.GetSnapshotObject(ctx)
 		if err != nil {
 			structure.warn(fmt.Sprintf("id<%s> type<%s> failed to get connected snapshot object", id, typ))

--- a/scenario/createsheet.go
+++ b/scenario/createsheet.go
@@ -2,10 +2,10 @@ package scenario
 
 import (
 	"context"
-	"github.com/qlik-oss/gopherciser/appstructure"
 
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/action"
+	"github.com/qlik-oss/gopherciser/appstructure"
 	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/creation"
 	"github.com/qlik-oss/gopherciser/session"
@@ -99,17 +99,17 @@ func (settings CreateSheetSettings) AffectsAppObjectsAction(structure appstructu
 		Objects: make([]appstructure.AppStructureObject, 0),
 	}
 	newObjs.Objects = append(newObjs.Objects, appstructure.AppStructureObject{
-		AppObjectDef:           appstructure.AppObjectDef{Id: settings.ID, Type: "sheet"},
-		MetaDef:                appstructure.MetaDef{Title: settings.Title},
-		RawBaseProperties:      nil,
-		RawExtendedProperties:  nil,
-		RawGeneratedProperties: nil,
-		Children:               nil,
-		Selectable:             false,
-		Dimensions:             nil,
-		Measures:               nil,
-		ExtendsId:              "",
-		Visualization:          "",
+		AppObjectDef:               appstructure.AppObjectDef{Id: settings.ID, Type: "sheet"},
+		MetaDef:                    appstructure.MetaDef{Title: settings.Title},
+		RawBaseProperties:          nil,
+		RawExtendedProperties:      nil,
+		RawGeneratedProperties:     nil,
+		AppStructureObjectChildren: appstructure.AppStructureObjectChildren{Children: nil},
+		Selectable:                 false,
+		Dimensions:                 nil,
+		Measures:                   nil,
+		ExtendsId:                  "",
+		Visualization:              "",
 	})
 	return []*appstructure.AppStructurePopulatedObjects{&newObjs}, nil, false
 }

--- a/scenario/createsheet.go
+++ b/scenario/createsheet.go
@@ -104,7 +104,7 @@ func (settings CreateSheetSettings) AffectsAppObjectsAction(structure appstructu
 		RawBaseProperties:          nil,
 		RawExtendedProperties:      nil,
 		RawGeneratedProperties:     nil,
-		AppStructureObjectChildren: appstructure.AppStructureObjectChildren{Children: nil},
+		AppStructureObjectChildren: appstructure.AppStructureObjectChildren{Map: nil},
 		Selectable:                 false,
 		Dimensions:                 nil,
 		Measures:                   nil,


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

* Add new array in structure array `storyobjects`. 
* Move all story and snapshot type of objects to `storyobjects` array instead of `objects` array.
* Connect all stories and snapshots so hierarchy can be traced. 
* Avoid getting app structure failing due to having `embeddedsnapshot" objects.

**Info**

Example file ( renamed to .txt so github would let me add it).
[31e1ab83-c896-4252-920f-a428ae5cbafe.txt](https://github.com/qlik-oss/gopherciser/files/5208876/31e1ab83-c896-4252-920f-a428ae5cbafe.txt)

when using the `--raw` flag, these fields will be added for some objects:
- `rawProperties`
- `rawSnapshotProperties`

