### PR TITLE
use new reload service result event instead of reload.ended

### DIFF
--- a/eventws/events.go
+++ b/eventws/events.go
@@ -19,4 +19,11 @@ const (
 	OperationReloadEnded       = "reload.ended"
 	OperationDataUpdated       = "data.updated"
 	OperationAttributesUpdated = "attributes.updated"
+	OperationResult            = "result"
+)
+
+// Constants for known ResourceType
+const (
+	ResourceTypeApp    = "app"
+	ResourceTypeReload = "reload"
 )

--- a/eventws/events.go
+++ b/eventws/events.go
@@ -2,14 +2,15 @@ package eventws
 
 type (
 	Event struct {
-		Operation    string `json:"operation,omitempty"`
-		Origin       string `json:"origin,omitempty"`
-		ResourceID   string `json:"resourceId,omitempty"`
-		ResourceType string `json:"resourceType,omitempty"`
-		Success      bool   `json:"success,omitempty"`
-		Time         string `json:"time,omitempty"`
-		SpaceId      string `json:"spaceId,omitempty"`
-		ReloadId     string `json:"reloadId,omitempty"`
+		Operation    string                 `json:"operation,omitempty"`
+		Origin       string                 `json:"origin,omitempty"`
+		ResourceID   string                 `json:"resourceId,omitempty"`
+		ResourceType string                 `json:"resourceType,omitempty"`
+		Success      bool                   `json:"success,omitempty"`
+		Time         string                 `json:"time,omitempty"`
+		SpaceId      string                 `json:"spaceId,omitempty"`
+		ReloadId     string                 `json:"reloadId,omitempty"`
+		Data         map[string]interface{} `json:"data,omitempty"`
 	}
 )
 

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -154,9 +154,9 @@ func (settings ElasticReloadSettings) execute(sessionState *session.State, actio
 			reloadEventChan <- &event
 		}
 	}, true)
-	eventEndedFunc := events.RegisterFunc(eventws.OperationReloadEnded, func(event eventws.Event) {
+	eventEndedFunc := events.RegisterFunc(eventws.OperationResult, func(event eventws.Event) {
 		defer helpers.RecoverWithError(nil)
-		if !helpers.IsContextTriggered(statusContext) {
+		if !helpers.IsContextTriggered(statusContext) && event.ResourceType == eventws.ResourceTypeReload {
 			reloadEventChan <- &event
 		}
 	}, true)
@@ -210,7 +210,7 @@ forLoop:
 				case eventws.OperationReloadStarted:
 					sessionState.LogEntry.LogDebugf("reload started time<%s>", event.Time)
 					reloadStarted = event.Time
-				case eventws.OperationReloadEnded:
+				case eventws.OperationResult:
 					sessionState.LogEntry.LogDebugf("reload ended time<%s> success<%v>", event.Time, event.Success)
 					if !event.Success {
 						actionState.AddErrors(errors.New("reload finished with success false"))

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -148,12 +148,13 @@ func (settings ElasticReloadSettings) execute(sessionState *session.State, actio
 	checkStatusChan := make(chan *eventws.Event)
 	statusContext, cancelStatusCheck := context.WithCancel(sessionState.BaseContext())
 	reloadEventChan := make(chan *eventws.Event)
-	eventStartedFunc := events.RegisterFunc(eventws.OperationReloadStarted, func(event eventws.Event) {
-		defer helpers.RecoverWithError(nil)
-		if !helpers.IsContextTriggered(statusContext) {
-			reloadEventChan <- &event
-		}
-	}, true)
+	// Temporarily disable started event as reloadID is missing
+	//eventStartedFunc := events.RegisterFunc(eventws.OperationReloadStarted, func(event eventws.Event) {
+	//	defer helpers.RecoverWithError(nil)
+	//	if !helpers.IsContextTriggered(statusContext) {
+	//		reloadEventChan <- &event
+	//	}
+	//}, true)
 	eventEndedFunc := events.RegisterFunc(eventws.OperationResult, func(event eventws.Event) {
 		defer helpers.RecoverWithError(nil)
 		if !helpers.IsContextTriggered(statusContext) && event.ResourceType == eventws.ResourceTypeReload {
@@ -177,7 +178,7 @@ func (settings ElasticReloadSettings) execute(sessionState *session.State, actio
 			events.DeRegisterFunc(wsReconnectFunc)
 			cancelStatusCheck()
 			events.DeRegisterFunc(eventEndedFunc)
-			events.DeRegisterFunc(eventStartedFunc)
+			//events.DeRegisterFunc(eventStartedFunc)
 			emptyAndCloseEventChan(checkStatusChan)
 			emptyAndCloseEventChan(reloadEventChan)
 		}()
@@ -193,7 +194,7 @@ func (settings ElasticReloadSettings) execute(sessionState *session.State, actio
 	}
 
 	reloadID := postReloadResponse.ID
-	reloadStarted := ""
+	//reloadStarted := ""
 forLoop:
 	for {
 		select {
@@ -205,33 +206,39 @@ forLoop:
 				break forLoop
 			}
 
-			// reloadiID is in data map instead of event.ReloadID if event is of type reload.result
-			if len(event.Data) < 1 {
-				actionState.AddErrors(errors.New("reload result event contains no data"))
-				break forLoop
-			}
-			reloadIDEntry, ok := event.Data["reloadId"]
-			if !ok {
-				actionState.AddErrors(errors.New("reload result event contains no reload ID"))
-				break forLoop
-			}
-			reloadID, ok := reloadIDEntry.(string)
-			if !ok {
-				actionState.AddErrors(errors.Errorf("reload result event contains reload id of unexpected type<%T> value<%v>", reloadIDEntry, reloadIDEntry))
-				break forLoop
+			eventReloadID := ""
+			switch event.Operation {
+			case eventws.OperationResult:
+				// reloadiID is in data map instead of event.ReloadID if event is of type reload.result
+				if len(event.Data) < 1 {
+					actionState.AddErrors(errors.New("reload result event contains no data"))
+					break forLoop
+				}
+				eventReloadIDEntry, ok := event.Data["reloadId"]
+				if !ok {
+					actionState.AddErrors(errors.New("reload result event contains no reload ID"))
+					break forLoop
+				}
+				eventReloadID, ok = eventReloadIDEntry.(string)
+				if !ok {
+					actionState.AddErrors(errors.Errorf("reload result event contains reload id of unexpected type<%T> value<%v>", eventReloadIDEntry, eventReloadIDEntry))
+					break forLoop
+				}
+			default:
+				eventReloadID = event.ReloadId
 			}
 
-			if reloadID == event.ReloadId {
+			if reloadID == eventReloadID {
 				switch event.Operation {
-				case eventws.OperationReloadStarted:
-					sessionState.LogEntry.LogDebugf("reload started time<%s>", event.Time)
-					reloadStarted = event.Time
+				//case eventws.OperationReloadStarted:
+				//	sessionState.LogEntry.LogDebugf("reload started time<%s>", event.Time)
+				//	reloadStarted = event.Time
 				case eventws.OperationResult:
 					sessionState.LogEntry.LogDebugf("reload ended time<%s> success<%v>", event.Time, event.Success)
 					if !event.Success {
 						actionState.AddErrors(errors.New("reload finished with success false"))
 					}
-					logReloadDuration(reloadStarted, event.Time, sessionState.LogEntry)
+					//logReloadDuration(reloadStarted, event.Time, sessionState.LogEntry)
 					break forLoop
 				}
 			}
@@ -282,22 +289,22 @@ func emptyAndCloseEventChan(c chan *eventws.Event) {
 	}
 }
 
-func logReloadDuration(started, ended string, logEntry *logger.LogEntry) {
-	startedTS, err := time.Parse(time.RFC3339, started)
-	if err != nil {
-		logEntry.Logf(logger.WarningLevel, "failed to parse reload started timestamp: %s", started)
-		return
-	}
-
-	endedTS, err := time.Parse(time.RFC3339, ended)
-	if err != nil {
-		logEntry.Logf(logger.WarningLevel, "failed to parse reload ended timestamp: %s", ended)
-		return
-	}
-
-	duration := endedTS.Sub(startedTS)
-	logEntry.LogInfo("ReloadDuration", fmt.Sprintf("%.fs", duration.Seconds())) // format to no decimals since timestamp is with entire seconds only
-}
+//func logReloadDuration(started, ended string, logEntry *logger.LogEntry) {
+//	startedTS, err := time.Parse(time.RFC3339, started)
+//	if err != nil {
+//		logEntry.Logf(logger.WarningLevel, "failed to parse reload started timestamp: %s", started)
+//		return
+//	}
+//
+//	endedTS, err := time.Parse(time.RFC3339, ended)
+//	if err != nil {
+//		logEntry.Logf(logger.WarningLevel, "failed to parse reload ended timestamp: %s", ended)
+//		return
+//	}
+//
+//	duration := endedTS.Sub(startedTS)
+//	logEntry.LogInfo("ReloadDuration", fmt.Sprintf("%.fs", duration.Seconds())) // format to no decimals since timestamp is with entire seconds only
+//}
 
 func checkStatusOngoing(sessionState *session.State, actionState *action.State, host, id string) (bool, error) {
 	reqOptions := session.DefaultReqOptions()

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -205,6 +205,22 @@ forLoop:
 				break forLoop
 			}
 
+			// reloadiID is in data map instead of event.ReloadID if event is of type reload.result
+			if len(event.Data) < 1 {
+				actionState.AddErrors(errors.New("reload result event contains no data"))
+				break forLoop
+			}
+			reloadIDEntry, ok := event.Data["reloadId"]
+			if !ok {
+				actionState.AddErrors(errors.New("reload result event contains no reload ID"))
+				break forLoop
+			}
+			reloadID, ok := reloadIDEntry.(string)
+			if !ok {
+				actionState.AddErrors(errors.Errorf("reload result event contains reload id of unexpected type<%T> value<%v>", reloadIDEntry, reloadIDEntry))
+				break forLoop
+			}
+
 			if reloadID == event.ReloadId {
 				switch event.Operation {
 				case eventws.OperationReloadStarted:


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Use new result event for reload instead of reload.ended.

**Info**

This is still not in an `eventing` release, (and thusly not yet tested). Will wait for new `eventing` version before testing/merging.
