### PR TITLE
Fix an issue where some linecharts yield a hypercube error

### DIFF
--- a/cmd/objdef.go
+++ b/cmd/objdef.go
@@ -212,10 +212,10 @@ func fileExists(name string) bool {
 
 func constraintString(data senseobjdef.Data, buf *helpers.Buffer) string {
 	if data.Constraints == nil {
-		buf.WriteString("|   Constraints: Default\n")
+		buf.WriteString("|   Constraint: Default\n")
 	} else {
 		for _, c := range data.Constraints {
-			buf.WriteString("|   Constraints: ")
+			buf.WriteString("|   Constraint: ")
 			buf.WriteString("[")
 			buf.WriteString(string(c.Path))
 			buf.WriteString("] ")

--- a/cmd/objdef.go
+++ b/cmd/objdef.go
@@ -211,11 +211,11 @@ func fileExists(name string) bool {
 }
 
 func constraintString(data senseobjdef.Data, buf *helpers.Buffer) string {
-	if data.Constraint == nil {
-		buf.WriteString("|   Constraint: Default\n")
+	if data.Constraints == nil {
+		buf.WriteString("|   Constraints: Default\n")
 	} else {
-		for _, c := range data.Constraint {
-			buf.WriteString("|   Constraint: ")
+		for _, c := range data.Constraints {
+			buf.WriteString("|   Constraints: ")
 			buf.WriteString("[")
 			buf.WriteString(string(c.Path))
 			buf.WriteString("] ")

--- a/cmd/objdef.go
+++ b/cmd/objdef.go
@@ -95,8 +95,8 @@ Use to export default values or examples or to validate custom definitions or ov
 		Use:     "validate",
 		Aliases: []string{"val", "v"},
 		Short:   "Validate object definitions in file.",
-		Long: `Validate object definitions from provided JSON file. Will print how many definitions where found,
-it's recommended to use to -v verbose flag and verify all parameters where interpreted correctly'`,
+		Long: `Validate object definitions from provided JSON file. Will print how many definitions were found,
+it's recommended to use to -v verbose flag and verify all parameters were interpreted correctly'`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if objDefFilePath == "" {
 				if err := cmd.Help(); err != nil {
@@ -214,14 +214,16 @@ func constraintString(data senseobjdef.Data, buf *helpers.Buffer) string {
 	if data.Constraint == nil {
 		buf.WriteString("|   Constraint: Default\n")
 	} else {
-		buf.WriteString("|   Constraint: ")
-		buf.WriteString("[")
-		buf.WriteString(string(data.Constraint.Path))
-		buf.WriteString("] ")
-		buf.WriteString(string(data.Constraint.Value))
-		buf.WriteString(" Required: ")
-		buf.WriteString(strconv.FormatBool(data.Constraint.Required))
-		buf.WriteString("\n")
+		for _, c := range data.Constraint {
+			buf.WriteString("|   Constraint: ")
+			buf.WriteString("[")
+			buf.WriteString(string(c.Path))
+			buf.WriteString("] ")
+			buf.WriteString(string(c.Value))
+			buf.WriteString(" Required: ")
+			buf.WriteString(strconv.FormatBool(c.Required))
+			buf.WriteString("\n")
+		}
 	}
 
 	buf.WriteString("|     ")

--- a/config/appstructure.go
+++ b/config/appstructure.go
@@ -339,7 +339,7 @@ func (structure *GeneratedAppStructure) handleDefaultObject(ctx context.Context,
 	}
 
 	// Lookup and set ExtendsID
-	extendsIdPath := senseobjdef.NewDataPath("/qExtendsId")
+	extendsIdPath := helpers.NewDataPath("/qExtendsId")
 	rawExtendsID, _ := extendsIdPath.Lookup(obj.RawBaseProperties)
 	_ = jsonit.Unmarshal(rawExtendsID, &obj.ExtendsId)
 
@@ -388,7 +388,7 @@ func (structure *GeneratedAppStructure) handleAutoChart(ctx context.Context, app
 }
 
 func extractGeneratedProperties(properties json.RawMessage) json.RawMessage {
-	generatedPropertiesPath := senseobjdef.NewDataPath("/qUndoExclude/generated")
+	generatedPropertiesPath := helpers.NewDataPath("/qUndoExclude/generated")
 	properties, _ = generatedPropertiesPath.Lookup(properties)
 	return properties
 }
@@ -424,7 +424,7 @@ func (structure *GeneratedAppStructure) handleObject(typ string, obj *appstructu
 	}
 
 	// Lookup and set Visualization
-	visualizationPath := senseobjdef.NewDataPath("/visualization")
+	visualizationPath := helpers.NewDataPath("/visualization")
 	rawVisualization, _ := visualizationPath.Lookup(properties)
 	_ = jsonit.Unmarshal(rawVisualization, &obj.Visualization)
 
@@ -433,7 +433,7 @@ func (structure *GeneratedAppStructure) handleObject(typ string, obj *appstructu
 		vis = typ
 	}
 
-	metaDef := senseobjdef.NewDataPath("/qMetaDef")
+	metaDef := helpers.NewDataPath("/qMetaDef")
 	rawMetaDef, _ := metaDef.Lookup(properties)
 	_ = jsonit.Unmarshal(rawMetaDef, &obj.MetaDef)
 
@@ -463,15 +463,15 @@ func (structure *GeneratedAppStructure) handleObject(typ string, obj *appstructu
 	obj.Selectable = def.Select != nil
 
 	// Paths dimensions and measures in hypercube
-	dimensions := senseobjdef.NewDataPath(fmt.Sprintf("%sDef/qDimensions", def.DataDef.Path))
-	measures := senseobjdef.NewDataPath(fmt.Sprintf("%sDef/qMeasures", def.DataDef.Path))
+	dimensions := helpers.NewDataPath(fmt.Sprintf("%sDef/qDimensions", def.DataDef.Path))
+	measures := helpers.NewDataPath(fmt.Sprintf("%sDef/qMeasures", def.DataDef.Path))
 
 	// Figure out list object path
 	listObjectPath := fmt.Sprintf("%sDef", def.DataDef.Path)
 	if !strings.HasSuffix(listObjectPath, "/qListObjectDef") {
 		listObjectPath = fmt.Sprintf("%s/qListObjectDef", def.DataDef.Path)
 	}
-	listObjects := senseobjdef.NewDataPath(listObjectPath)
+	listObjects := helpers.NewDataPath(listObjectPath)
 
 	// Try to set dimensions and measures, null if not exist or not parsable (error)
 	rawDimensions, _ := dimensions.Lookup(properties)
@@ -571,7 +571,7 @@ func (structure *GeneratedAppStructure) handleMeasure(ctx context.Context, app *
 
 	// Save measure information to structure
 	var measure enigma.NxInlineMeasureDef
-	measurePath := senseobjdef.NewDataPath("/qMeasure")
+	measurePath := helpers.NewDataPath("/qMeasure")
 	rawMeasure, err := measurePath.Lookup(obj.RawBaseProperties)
 	if err != nil {
 		structure.warn(fmt.Sprintf("measure<%s> definition not found", id))
@@ -583,7 +583,7 @@ func (structure *GeneratedAppStructure) handleMeasure(ctx context.Context, app *
 
 	// Save meta information to structure
 	var meta appstructure.MetaDef
-	metaPath := senseobjdef.NewDataPath("/qMetaDef")
+	metaPath := helpers.NewDataPath("/qMetaDef")
 	rawMeta, err := metaPath.Lookup(obj.RawBaseProperties)
 	if err != nil {
 		structure.warn(fmt.Sprintf("measure<%s> has not meta information", id))
@@ -616,7 +616,7 @@ func (structure *GeneratedAppStructure) handleDimension(ctx context.Context, app
 
 	// Save dimension information to structure
 	var dimension enigma.NxInlineDimensionDef
-	dimensionPath := senseobjdef.NewDataPath("/qDim")
+	dimensionPath := helpers.NewDataPath("/qDim")
 	rawDimension, err := dimensionPath.Lookup(obj.RawBaseProperties)
 	if err != nil {
 		structure.warn(fmt.Sprintf("dimension<%s> defintion not found", id))
@@ -628,7 +628,7 @@ func (structure *GeneratedAppStructure) handleDimension(ctx context.Context, app
 
 	// Add dimension meta information to structure
 	var meta appstructure.MetaDef
-	metaPath := senseobjdef.NewDataPath("/qMetaDef")
+	metaPath := helpers.NewDataPath("/qMetaDef")
 	rawMeta, err := metaPath.Lookup(obj.RawBaseProperties)
 	if err != nil {
 		structure.warn(fmt.Sprintf("dimension<%s> has not meta information", id))
@@ -693,7 +693,7 @@ func (structure *GeneratedAppStructure) handleStories(ctx context.Context, app *
 	}()
 
 	// Lookup and set Visualization
-	visualizationPath := senseobjdef.NewDataPath("/visualization")
+	visualizationPath := helpers.NewDataPath("/visualization")
 	rawVisualization, _ := visualizationPath.Lookup(storyObject.RawProperties)
 	_ = jsonit.Unmarshal(rawVisualization, &storyObject.Visualization)
 
@@ -739,7 +739,7 @@ func (structure *GeneratedAppStructure) handleBookmark(ctx context.Context, app 
 
 	// Get bookmark meta information
 	var meta appstructure.MetaDef // meta shares title and description from this struct
-	metaPath := senseobjdef.NewDataPath("/qMetaDef")
+	metaPath := helpers.NewDataPath("/qMetaDef")
 	rawMeta, err := metaPath.Lookup(properties)
 	if err != nil {
 		structure.warn(fmt.Sprintf("bookmark<%s> has no meta information", id))
@@ -755,7 +755,7 @@ func (structure *GeneratedAppStructure) handleBookmark(ctx context.Context, app 
 		structureBookmark.RawProperties = properties
 	}
 
-	idPath := senseobjdef.NewDataPath("/qInfo/qId")
+	idPath := helpers.NewDataPath("/qInfo/qId")
 	rawId, err := idPath.Lookup(properties)
 	if err != nil {
 		return errors.Wrap(err, "failed to get ID of bookmark")
@@ -861,7 +861,7 @@ func resolveTitle(obj *appstructure.AppStructureObject, properties json.RawMessa
 }
 
 func stringFromDataPath(path string, data json.RawMessage) string {
-	dataPath := senseobjdef.NewDataPath(path)
+	dataPath := helpers.NewDataPath(path)
 	rawData, _ := dataPath.Lookup(data)
 	var str string
 	_ = jsonit.Unmarshal(rawData, &str)

--- a/docs/sense-object-definitions.md
+++ b/docs/sense-object-definitions.md
@@ -209,7 +209,7 @@ A list of data requests to send for an object, with the possibility to send diff
 
 * `constraints`: A list of constraints for sending the defined set of data requests. An empty or omitted constraint is always considered to be  true.
     * `path`: Path to the value to evaluate in the object structure.
-    * `value`: Value constraint definition. The first character must be `<`, `>`, `=`, `!` or `~` followed by a number, string or the words `true` / `false`. The `~` operator is only applicable to string arrays and is defined as `contains`.
+    * `value`: Value constraint definition. The first character must be `<`, `>`, `=`, `!` or `~` followed by a number, string or the words `true` / `false`. The `~` operator is only applicable to arrays and is defined as `contains`.
     * `required`: Require the constraint to be evaluated and return an error if the evaluation fails (for example, if the path in the object structure is not traversable). Defaults to `false`.
 * `requests`: List of data requests to send if the constraint is successfully evaluated. A request is defined as:
     * `type`: Data request type

--- a/docs/sense-object-definitions.md
+++ b/docs/sense-object-definitions.md
@@ -205,11 +205,11 @@ An object definition consists of the following sections:
 
 ### Data
 
-A list of data requests to send for an object, with the possibility to send different requests depending on different  constraints. The list of constraints is evaluated top-down, where the first constraint fulfilled is used. "Nil" requests are always considered to be true (that is, if the list of constraints starts with an entry without a constraint, the subsequent constraints are not used). It is therefore important to start the list with the constraint to be evaluated first. In the above `scatterplot` example, the constraint "qcy > 1000" is evaluated before performing the default operation.
+A list of data requests to send for an object, with the possibility to send different requests depending on different constraints. The list of constraints is evaluated top-down, where the first constraint fulfilled is used. "Nil" requests are always considered to be true (that is, if the list of constraints starts with an entry without a constraint, the subsequent constraints are not used). It is therefore important to start the list with the constraint to be evaluated first. In the above `scatterplot` example, the constraint "qcy > 1000" is evaluated before performing the default operation.
 
-* `constraint`: Constraint for sending the defined set of data requests. An empty or omitted constraint is always considered to be  true.
+* `constraints`: A list of constraints for sending the defined set of data requests. An empty or omitted constraint is always considered to be  true.
     * `path`: Path to the value to evaluate in the object structure.
-    * `value`: Value constraint definition. The first character must be `<`, `>`, `=` or `!` followed by a number or the words `true` / `false`. 
+    * `value`: Value constraint definition. The first character must be `<`, `>`, `=`, `!` or `~` followed by a number, string or the words `true` / `false`. The `~` operator is only applicable to string arrays and is defined as `contains`.
     * `required`: Require the constraint to be evaluated and return an error if the evaluation fails (for example, if the path in the object structure is not traversable). Defaults to `false`.
 * `requests`: List of data requests to send if the constraint is successfully evaluated. A request is defined as:
     * `type`: Data request type
@@ -267,11 +267,13 @@ An object that sends different data requests depending on the size of the data:
     },
     "data": [
       {
-        "constraint": {
-          "path": "/qHyperCube/qSize/qcy",
-          "value": ">1000",
-          "required": true
-        },
+        "constraints": [
+          {
+            "path": "/qHyperCube/qSize/qcy",
+            "value": ">1000",
+            "required": true
+          }
+        ],
         "requests": [
           {
             "type": "hypercubebinneddata",

--- a/helpers/datapath.go
+++ b/helpers/datapath.go
@@ -1,4 +1,4 @@
-package senseobjdef
+package helpers
 
 import (
 	"encoding/json"

--- a/helpers/datapath_test.go
+++ b/helpers/datapath_test.go
@@ -1,4 +1,4 @@
-package senseobjdef
+package helpers
 
 import (
 	"encoding/json"

--- a/helpers/jsonhelpers.go
+++ b/helpers/jsonhelpers.go
@@ -1,0 +1,21 @@
+package helpers
+
+import (
+	"github.com/pkg/errors"
+	"strings"
+)
+
+// HasDeprecatedFields check json if keys exist at provided paths, if any exist report error
+func HasDeprecatedFields(rawJson []byte, deprecatedPaths []string) error {
+	hasPaths := make([]string, 0, len(deprecatedPaths))
+	for _, path := range deprecatedPaths {
+		dp := DataPath(path)
+		if _, err := dp.Lookup(rawJson); err == nil {
+			hasPaths = append(hasPaths, path)
+		}
+	}
+	if len(hasPaths) > 0 {
+		return errors.Errorf("has deprecated fields: %s", strings.Join(hasPaths, ","))
+	}
+	return nil
+}

--- a/helpers/jsonhelpers_test.go
+++ b/helpers/jsonhelpers_test.go
@@ -1,4 +1,4 @@
-package scenario
+package helpers
 
 import (
 	"encoding/json"

--- a/scenario/clickactionbutton.go
+++ b/scenario/clickactionbutton.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"strconv"
 	"strings"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/enigmahandlers"
 	"github.com/qlik-oss/gopherciser/enummap"
-	"github.com/qlik-oss/gopherciser/senseobjdef"
 	"github.com/qlik-oss/gopherciser/session"
 )
 
@@ -179,7 +179,7 @@ func buttonActions(sessionState *session.State, actionState *action.State, obj *
 		}
 
 		// parse button actions
-		actionsRaw, err := senseobjdef.NewDataPath("actions").Lookup(propsRaw)
+		actionsRaw, err := helpers.NewDataPath("actions").Lookup(propsRaw)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, `no "actions"-property exist for object<%s>`, obj.ID)
 		}
@@ -191,7 +191,7 @@ func buttonActions(sessionState *session.State, actionState *action.State, obj *
 		}
 
 		// parse navigation action associated with button
-		navigationRaw, err := senseobjdef.NewDataPath("navigation").Lookup(propsRaw)
+		navigationRaw, err := helpers.NewDataPath("navigation").Lookup(propsRaw)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, `no "navigation"-property exist for object<%s>`, obj.ID)
 		}

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -41,7 +41,7 @@ const (
 
 // UnmarshalJSON unmarshals reload settings from JSON
 func (settings *ElasticReloadSettings) UnmarshalJSON(arg []byte) error {
-	if err := HasDeprecatedFields(arg, []string{
+	if err := helpers.HasDeprecatedFields(arg, []string{
 		"/appguid",
 		"/appname",
 		"/pollinterval",

--- a/scenario/helpers.go
+++ b/scenario/helpers.go
@@ -3,10 +3,6 @@ package scenario
 import (
 	"context"
 	"fmt"
-	"strings"
-
-	"github.com/qlik-oss/gopherciser/senseobjdef"
-
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/enigma-go"
 	"github.com/qlik-oss/gopherciser/action"
@@ -142,19 +138,4 @@ func (getVar varReq) WithCache(vc *enigmahandlers.VarCache) varReq {
 		vc.Store(varName, variable)
 		return variable, nil
 	}
-}
-
-// HasDeprecatedFields check json if keys exist at provided paths, if any exist report error
-func HasDeprecatedFields(rawJson []byte, deprecatedPaths []string) error {
-	hasPaths := make([]string, 0, len(deprecatedPaths))
-	for _, path := range deprecatedPaths {
-		dp := senseobjdef.DataPath(path)
-		if _, err := dp.Lookup(rawJson); err == nil {
-			hasPaths = append(hasPaths, path)
-		}
-	}
-	if len(hasPaths) > 0 {
-		return errors.Errorf("has deprecated fields: %s", strings.Join(hasPaths, ","))
-	}
-	return nil
 }

--- a/senseobjdef/constraint.go
+++ b/senseobjdef/constraint.go
@@ -49,11 +49,11 @@ const (
 
 var (
 	constraintOperatorEnum = enummap.NewEnumMapOrPanic(map[string]int{
-		"<":         int(lessThanOperator),
-		">":         int(largerThanOperator),
-		"=":         int(equalOperator),
-		"!":         int(notOperator),
-		"contains:": int(containsOperator),
+		"<": int(lessThanOperator),
+		">": int(largerThanOperator),
+		"=": int(equalOperator),
+		"!": int(notOperator),
+		"~": int(containsOperator),
 	})
 )
 

--- a/senseobjdef/constraint.go
+++ b/senseobjdef/constraint.go
@@ -165,12 +165,12 @@ func (operator constraintOperator) evalFloat64(val float64, constraint float64) 
 	}
 }
 
-func (operator constraintOperator) evalBool(val bool, contraint bool) (bool, error) {
+func (operator constraintOperator) evalBool(val bool, constraint bool) (bool, error) {
 	switch operator {
 	case equalOperator:
-		return val == contraint, nil
+		return val == constraint, nil
 	case notOperator:
-		return val != contraint, nil
+		return val != constraint, nil
 	default:
 		str, _ := constraintOperatorEnum.String(int(operator))
 		if str == "" {

--- a/senseobjdef/constraint.go
+++ b/senseobjdef/constraint.go
@@ -3,6 +3,7 @@ package senseobjdef
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"reflect"
 	"strconv"
 	"sync"
@@ -23,7 +24,7 @@ type (
 	// Constraint defining if to send get data requests
 	Constraint struct {
 		// Path to value to evaluate
-		Path DataPath `json:"path"`
+		Path helpers.DataPath `json:"path"`
 		// Value constraint definition, first character must be <,>,= or !
 		// followed by number or the words true/false
 		Value ConstraintValue `json:"value"`
@@ -111,7 +112,7 @@ func (constraint *Constraint) Evaluate(data json.RawMessage) (bool, error) {
 			string(constraint.Value), string(constraint.Path))
 
 		switch errors.Cause(err).(type) {
-		case NoDataFound:
+		case helpers.NoDataFound:
 			if !constraint.Required {
 				err = nil
 			}

--- a/senseobjdef/constraint.go
+++ b/senseobjdef/constraint.go
@@ -44,14 +44,16 @@ const (
 	largerThanOperator
 	equalOperator
 	notOperator
+	containsOperator
 )
 
 var (
 	constraintOperatorEnum = enummap.NewEnumMapOrPanic(map[string]int{
-		"<": int(lessThanOperator),
-		">": int(largerThanOperator),
-		"=": int(equalOperator),
-		"!": int(notOperator),
+		"<":         int(lessThanOperator),
+		">":         int(largerThanOperator),
+		"=":         int(equalOperator),
+		"!":         int(notOperator),
+		"contains:": int(containsOperator),
 	})
 )
 

--- a/senseobjdef/constraint_test.go
+++ b/senseobjdef/constraint_test.go
@@ -28,7 +28,7 @@ func TestConstraintValue(t *testing.T) {
 	}`
 
 	type testData struct {
-		contraint      *Constraint
+		constraint     *Constraint
 		expectedResult bool
 		expectedErr    error
 	}
@@ -218,14 +218,14 @@ func TestConstraintValue(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			result, err := test.contraint.Evaluate(json.RawMessage(jsonData))
+			result, err := test.constraint.Evaluate(json.RawMessage(jsonData))
 			if errors.Cause(err) != test.expectedErr {
 				t.Error(err)
 			}
 
 			if result != test.expectedResult {
 				t.Errorf("result<%v> not expected<%v> constraint<%s>",
-					result, test.expectedResult, string(test.contraint.Value))
+					result, test.expectedResult, string(test.constraint.Value))
 			}
 		})
 	}

--- a/senseobjdef/constraint_test.go
+++ b/senseobjdef/constraint_test.go
@@ -2,6 +2,7 @@ package senseobjdef
 
 import (
 	"encoding/json"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"strconv"
 	"testing"
 
@@ -37,177 +38,177 @@ func TestConstraintValue(t *testing.T) {
 		//float64 tests
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("=100"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("=50"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("<500"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("<100"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("<50"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue(">50"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue(">500"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue(">100"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("!50"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("!100"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[0]/toEval"),
+				Path:  helpers.DataPath("/some/data/[0]/toEval"),
 				Value: ConstraintValue("*100"),
 			}, false, MalformedConstraintValueError("*100"),
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[1]/toEval"),
+				Path:  helpers.DataPath("/some/data/[1]/toEval"),
 				Value: ConstraintValue("=4.6"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[1]/toEval"),
+				Path:  helpers.DataPath("/some/data/[1]/toEval"),
 				Value: ConstraintValue("!4.6"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[1]/toEval"),
+				Path:  helpers.DataPath("/some/data/[1]/toEval"),
 				Value: ConstraintValue("<5"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[1]/toEval"),
+				Path:  helpers.DataPath("/some/data/[1]/toEval"),
 				Value: ConstraintValue(">4"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[2]/toEval"),
+				Path:  helpers.DataPath("/some/data/[2]/toEval"),
 				Value: ConstraintValue("=-23.154"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[2]/toEval"),
+				Path:  helpers.DataPath("/some/data/[2]/toEval"),
 				Value: ConstraintValue("<-23.153"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[2]/toEval"),
+				Path:  helpers.DataPath("/some/data/[2]/toEval"),
 				Value: ConstraintValue(">3.154"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[2]/toEval"),
+				Path:  helpers.DataPath("/some/data/[2]/toEval"),
 				Value: ConstraintValue("!-23.154"),
 			}, false, nil,
 		},
 		//bool tests
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("=true"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("=1"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("=false"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("!false"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("!0"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[3]/toEval"),
+				Path:  helpers.DataPath("/some/data/[3]/toEval"),
 				Value: ConstraintValue("!true"),
 			}, false, nil,
 		},
 		//string tests
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[4]/toEval"),
+				Path:  helpers.DataPath("/some/data/[4]/toEval"),
 				Value: ConstraintValue("=sometext"),
 			}, true, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[4]/toEval"),
+				Path:  helpers.DataPath("/some/data/[4]/toEval"),
 				Value: ConstraintValue("=notmytext"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[4]/toEval"),
+				Path:  helpers.DataPath("/some/data/[4]/toEval"),
 				Value: ConstraintValue("!sometext"),
 			}, false, nil,
 		},
 		{
 			&Constraint{
-				Path:  DataPath("/some/data/[4]/toEval"),
+				Path:  helpers.DataPath("/some/data/[4]/toEval"),
 				Value: ConstraintValue("!mytext"),
 			}, true, nil,
 		},

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -131,11 +131,18 @@ var (
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
 			{
-				[]*Constraint{&Constraint{
-					Path:     "/dimensionAxis/continuousAuto",
-					Value:    "=true",
-					Required: false,
-				}},
+				[]*Constraint{
+					&Constraint{
+						Path:     "/dimensionAxis/continuousAuto",
+						Value:    "=true",
+						Required: false,
+					},
+					&Constraint{
+						Path:     "/qHyperCube/qDimensionInfo/qTags",
+						Value:    "contains:$numeric",
+						Required: false,
+					},
+				},
 				[]GetDataRequests{
 					{
 						Type: DataTypeHyperCubeContinuousData,

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -133,7 +133,7 @@ var (
 			{
 				[]*Constraint{
 					&Constraint{
-						Path:     "/dimensionAxis/continuousAuto",
+						Path:     "/preferContinuousAxis",
 						Value:    "=true",
 						Required: false,
 					},

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -138,7 +138,7 @@ var (
 						Required: false,
 					},
 					&Constraint{
-						Path:     "/qHyperCube/qDimensionInfo/qTags",
+						Path:     "/qHyperCube/qDimensionInfo/[0]/qTags",
 						Value:    "~$numeric",
 						Required: false,
 					},

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -139,7 +139,7 @@ var (
 					},
 					&Constraint{
 						Path:     "/qHyperCube/qDimensionInfo/qTags",
-						Value:    "contains:$numeric",
+						Value:    "~$numeric",
 						Required: false,
 					},
 				},

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -5,11 +5,11 @@ var (
 	DefaultListboxDef = ObjectDef{
 		DataDef{DataDefListObject, "/qListObject"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{DataTypeListObject, "/qListObjectDef", DefaultDataHeight},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeListObjectValues, "/qListObjectDef"},
 	}
@@ -25,11 +25,11 @@ var (
 	DefaultBarchart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{DataTypeHyperCubeReducedData, "/qHyperCubeDef", DefaultDataHeight},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -38,7 +38,7 @@ var (
 	DefaultScatterplot = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				[]*Constraint{&Constraint{
 					Path:     "/qHyperCube/qSize/qcy",
 					Value:    ">1000",
@@ -50,8 +50,8 @@ var (
 						Path: "/qHyperCubeDef",
 					},
 				},
-			},
-			{
+			}},
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						DataTypeHyperCubeData,
@@ -59,7 +59,7 @@ var (
 						1000,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -68,13 +68,13 @@ var (
 	DefaultMap = ObjectDef{
 		DataDef{DataDefHyperCube, "/qUndoExclude/gaLayers/[0]/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qUndoExclude/gaLayers/0/qHyperCubeDef"},
 	}
@@ -83,13 +83,13 @@ var (
 	DefaultCombochart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -98,7 +98,7 @@ var (
 	DefaultTable = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						DataTypeHyperCubeDataColumns,
@@ -106,7 +106,7 @@ var (
 						40,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeColumnValues, "/qHyperCubeDef"},
 	}
@@ -115,13 +115,13 @@ var (
 	DefaultPivotTable = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -130,7 +130,7 @@ var (
 	DefaultLinechart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				[]*Constraint{
 					&Constraint{
 						Path:     "/preferContinuousAxis",
@@ -149,14 +149,14 @@ var (
 						Path: "/qHyperCubeDef",
 					},
 				},
-			}, {
+			}}, {DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeReducedData,
 						Path: "/qHyperCubeDef",
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -165,13 +165,13 @@ var (
 	DefaultPiechart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -180,13 +180,13 @@ var (
 	DefaultTreemap = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -195,13 +195,13 @@ var (
 	DefaultMekkoChart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qHyperCubeDef"},
 	}
@@ -210,13 +210,13 @@ var (
 	DefaultTextImage = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -225,13 +225,13 @@ var (
 	DefaultKpi = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -240,13 +240,13 @@ var (
 	DefaultGauge = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -255,7 +255,7 @@ var (
 	DefaultBoxplot = ObjectDef{
 		DataDef{DataDefHyperCube, "/qUndoExclude/box/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeData,
@@ -266,7 +266,7 @@ var (
 						Path: "/qUndoExclude/outliers/qHyperCubeDef",
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qUndoExclude/box/qHyperCubeDef"},
 	}
@@ -275,14 +275,14 @@ var (
 	DefaultDistributionplot = ObjectDef{
 		DataDef{DataDefHyperCube, "/qUndoExclude/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeStackData,
 						Path: "/qUndoExclude/qHyperCubeDef",
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qUndoExclude/qHyperCubeDef"},
 	}
@@ -291,14 +291,14 @@ var (
 	DefaultHistogram = ObjectDef{
 		DataDef{DataDefHyperCube, "/qUndoExclude/box/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeData,
 						Path: "/qUndoExclude/box/qHyperCubeDef",
 					},
 				},
-			},
+			}},
 		},
 		&Select{SelectTypeHypercubeValues, "/qUndoExclude/box/qHyperCubeDef"},
 	}
@@ -307,13 +307,13 @@ var (
 	DefaultWaterfallChart = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -322,13 +322,13 @@ var (
 	DefaultQlikFunnelChartExt = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -340,13 +340,13 @@ var (
 	DefaultQlikSankeyChartExt = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -358,13 +358,13 @@ var (
 	DefaultQlikWordCloud = ObjectDef{
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -378,13 +378,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -398,13 +398,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -415,13 +415,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -435,13 +435,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -455,13 +455,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 	}
@@ -472,13 +472,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -492,13 +492,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		nil,
 		// heatmap sends two selects, one SelectHyperCubeValues each for dimension 0 and 1 for each selection made.
@@ -515,13 +515,13 @@ var (
 			Path: "/qHyperCube",
 		},
 		Data: []Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		Select: &Select{
 			Type: SelectTypeHypercubeValues,
@@ -534,13 +534,13 @@ var (
 			Type: DataDefNoData,
 		},
 		Data: []Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		Select: nil,
 	}
@@ -551,13 +551,13 @@ var (
 			Path: "/qHyperCubeDef",
 		},
 		[]Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		&Select{
 			Type: SelectTypeHypercubeValues,
@@ -570,13 +570,13 @@ var (
 			Type: DataDefNoData,
 		},
 		Data: []Data{
-			{
+			{DataCore{
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeLayout,
 					},
 				},
-			},
+			}},
 		},
 		Select: nil,
 	}

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -39,11 +39,11 @@ var (
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
 			{
-				&Constraint{
+				[]*Constraint{&Constraint{
 					Path:     "/qHyperCube/qSize/qcy",
 					Value:    ">1000",
 					Required: true,
-				},
+				}},
 				[]GetDataRequests{
 					{
 						Type: DataTypeHyperCubeBinnedData,
@@ -131,11 +131,11 @@ var (
 		DataDef{DataDefHyperCube, "/qHyperCube"},
 		[]Data{
 			{
-				&Constraint{
+				[]*Constraint{&Constraint{
 					Path:     "/dimensionAxis/continuousAuto",
 					Value:    "=true",
 					Required: false,
-				},
+				}},
 				[]GetDataRequests{
 					{
 						Type: DataTypeHyperCubeContinuousData,

--- a/senseobjdef/senseobjdef.go
+++ b/senseobjdef/senseobjdef.go
@@ -39,8 +39,8 @@ type (
 
 	// Data Get data definitions
 	Data struct {
-		// Constraint constraint defining if to send requests
-		Constraint []*Constraint `json:"constraint,omitempty"`
+		// Constraints constraint defining if to send requests
+		Constraints []*Constraint `json:"constraints,omitempty"`
 		// Requests List of data requests to send
 		Requests []GetDataRequests `json:"requests,omitempty"`
 	}
@@ -361,7 +361,7 @@ func (def *ObjectDef) Validate() error {
 func (def *ObjectDef) Evaluate(data json.RawMessage) ([]GetDataRequests, error) {
 	for _, v := range def.Data {
 		meetsConstraints := true
-		for _, c := range v.Constraint {
+		for _, c := range v.Constraints {
 
 			result, err := c.Evaluate(data)
 			if err != nil {

--- a/senseobjdef/senseobjdef_test.go
+++ b/senseobjdef/senseobjdef_test.go
@@ -39,10 +39,10 @@ var (
 			},
 			Data: []Data{
 				{
-					Constraint: &Constraint{
+					Constraint: []*Constraint{&Constraint{
 						Path:  "/qHyperCube/qSize/qcy",
 						Value: ">1000",
-					},
+					}},
 					Requests: []GetDataRequests{
 						{
 							Type:   DataTypeHyperCubeBinnedData,
@@ -76,10 +76,10 @@ func TestConstraints(t *testing.T) {
 	def := &ObjectDef{
 		Data: []Data{
 			{
-				Constraint: &Constraint{
+				Constraint: []*Constraint{&Constraint{
 					Path:  DataPath("/qHyperCube/qSize/qcy"),
 					Value: ConstraintValue(">1000"),
-				},
+				}},
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeBinnedData,
@@ -169,10 +169,10 @@ func TestConfig(t *testing.T) {
 			},
 			"data": [
 				{
-					"constraint": {
+					"constraint": [{
 						"path": "/qHyperCube/qSize/qcy",
 						"value": ">1000"
-					},
+					}],
 					"requests": [
 						{
 							"type": "HyperCubeBinnedData",
@@ -212,7 +212,7 @@ func TestConfig(t *testing.T) {
 	objDefs := string(jString)
 	t.Log("marshaled json:", objDefs)
 
-	expectedJSON := `{"customscatterplot":{"datadef":{"type":"hypercube","path":"/qHyperCube"},"data":[{"constraint":{"path":"/qHyperCube/qSize/qcy","value":"\u003e1000"},"requests":[{"type":"hypercubebinneddata","path":"/qHyperCubeDef","height":10000}]},{"requests":[{"type":"hypercubedata","path":"/qHyperCubeDef","height":1000}]}],"select":{"type":"hypercubevalues","path":"/qHyperCubeDef"}},"listbox":{"datadef":{"type":"listobject","path":"/qListObject"},"data":[{"requests":[{"type":"listobjectdata","path":"/qListObjectDef","height":10000}]}],"select":{"type":"listobjectvalues","path":"/qListObjectDef"}}}`
+	expectedJSON := `{"customscatterplot":{"datadef":{"type":"hypercube","path":"/qHyperCube"},"data":[{"constraint":[{"path":"/qHyperCube/qSize/qcy","value":"\u003e1000"}],"requests":[{"type":"hypercubebinneddata","path":"/qHyperCubeDef","height":10000}]},{"requests":[{"type":"hypercubedata","path":"/qHyperCubeDef","height":1000}]}],"select":{"type":"hypercubevalues","path":"/qHyperCubeDef"}},"listbox":{"datadef":{"type":"listobject","path":"/qListObject"},"data":[{"requests":[{"type":"listobjectdata","path":"/qListObjectDef","height":10000}]}],"select":{"type":"listobjectvalues","path":"/qListObjectDef"}}}`
 	if objDefs != expectedJSON {
 		t.Log("expected json:", expectedJSON)
 		t.Error("unexpected marshaled json")
@@ -371,8 +371,10 @@ func validateData(object string, data []Data, test []Data) error {
 	}
 
 	for i, v := range data {
-		if err := validateConstraint(object, v.Constraint, test[i].Constraint); err != nil {
-			return err
+		for j, c := range v.Constraint {
+			if err := validateConstraint(object, c, test[i].Constraint[j]); err != nil {
+				return err
+			}
 		}
 
 		if err := validateRequests(object, v.Requests, test[i].Requests); err != nil {

--- a/senseobjdef/senseobjdef_test.go
+++ b/senseobjdef/senseobjdef_test.go
@@ -17,7 +17,7 @@ var (
 			},
 			Data: []Data{
 				{
-					Constraint: nil,
+					Constraints: nil,
 					Requests: []GetDataRequests{
 						{
 							Type:   DataTypeListObject,
@@ -39,7 +39,7 @@ var (
 			},
 			Data: []Data{
 				{
-					Constraint: []*Constraint{&Constraint{
+					Constraints: []*Constraint{&Constraint{
 						Path:  "/qHyperCube/qSize/qcy",
 						Value: ">1000",
 					}},
@@ -52,7 +52,7 @@ var (
 					},
 				},
 				{
-					Constraint: nil,
+					Constraints: nil,
 					Requests: []GetDataRequests{
 						{
 							Type:   DataTypeHyperCubeData,
@@ -76,7 +76,7 @@ func TestConstraints(t *testing.T) {
 	def := &ObjectDef{
 		Data: []Data{
 			{
-				Constraint: []*Constraint{&Constraint{
+				Constraints: []*Constraint{&Constraint{
 					Path:  DataPath("/qHyperCube/qSize/qcy"),
 					Value: ConstraintValue(">1000"),
 				}},
@@ -86,7 +86,7 @@ func TestConstraints(t *testing.T) {
 					},
 				},
 			}, {
-				Constraint: nil,
+				Constraints: nil,
 				Requests: []GetDataRequests{
 					{
 						Type: DataTypeHyperCubeData,
@@ -169,7 +169,7 @@ func TestConfig(t *testing.T) {
 			},
 			"data": [
 				{
-					"constraint": [{
+					"constraints": [{
 						"path": "/qHyperCube/qSize/qcy",
 						"value": ">1000"
 					}],
@@ -212,7 +212,7 @@ func TestConfig(t *testing.T) {
 	objDefs := string(jString)
 	t.Log("marshaled json:", objDefs)
 
-	expectedJSON := `{"customscatterplot":{"datadef":{"type":"hypercube","path":"/qHyperCube"},"data":[{"constraint":[{"path":"/qHyperCube/qSize/qcy","value":"\u003e1000"}],"requests":[{"type":"hypercubebinneddata","path":"/qHyperCubeDef","height":10000}]},{"requests":[{"type":"hypercubedata","path":"/qHyperCubeDef","height":1000}]}],"select":{"type":"hypercubevalues","path":"/qHyperCubeDef"}},"listbox":{"datadef":{"type":"listobject","path":"/qListObject"},"data":[{"requests":[{"type":"listobjectdata","path":"/qListObjectDef","height":10000}]}],"select":{"type":"listobjectvalues","path":"/qListObjectDef"}}}`
+	expectedJSON := `{"customscatterplot":{"datadef":{"type":"hypercube","path":"/qHyperCube"},"data":[{"constraints":[{"path":"/qHyperCube/qSize/qcy","value":"\u003e1000"}],"requests":[{"type":"hypercubebinneddata","path":"/qHyperCubeDef","height":10000}]},{"requests":[{"type":"hypercubedata","path":"/qHyperCubeDef","height":1000}]}],"select":{"type":"hypercubevalues","path":"/qHyperCubeDef"}},"listbox":{"datadef":{"type":"listobject","path":"/qListObject"},"data":[{"requests":[{"type":"listobjectdata","path":"/qListObjectDef","height":10000}]}],"select":{"type":"listobjectvalues","path":"/qListObjectDef"}}}`
 	if objDefs != expectedJSON {
 		t.Log("expected json:", expectedJSON)
 		t.Error("unexpected marshaled json")
@@ -282,8 +282,8 @@ func TestDefault(t *testing.T) {
 			t.Errorf("incorrect amount of data constraints for treemap<%d> expected<%d>", dataConstraintsCount, expectedDataConstraintsCount)
 		} else {
 			dataConstraint := treemap.Data[0]
-			if dataConstraint.Constraint != nil {
-				t.Error("tree map contains unexpected data request constraint:", dataConstraint.Constraint)
+			if dataConstraint.Constraints != nil {
+				t.Error("tree map contains unexpected data request constraint:", dataConstraint.Constraints)
 			}
 
 			dataRequestsCount := len(dataConstraint.Requests)
@@ -371,8 +371,8 @@ func validateData(object string, data []Data, test []Data) error {
 	}
 
 	for i, v := range data {
-		for j, c := range v.Constraint {
-			if err := validateConstraint(object, c, test[i].Constraint[j]); err != nil {
+		for j, c := range v.Constraints {
+			if err := validateConstraint(object, c, test[i].Constraints[j]); err != nil {
 				return err
 			}
 		}
@@ -390,16 +390,16 @@ func validateConstraint(object string, constraint *Constraint, test *Constraint)
 		if constraint == test {
 			return nil
 		}
-		return fmt.Errorf("object<%s> contraint<%+v> not expected<%+v>", object, constraint, test)
+		return fmt.Errorf("object<%s> constraint<%+v> not expected<%+v>", object, constraint, test)
 	}
 
 	if string(constraint.Path) != string(test.Path) {
-		return fmt.Errorf("object<%s> contraint path<%s> not expected<%s>",
+		return fmt.Errorf("object<%s> constraint path<%s> not expected<%s>",
 			object, string(constraint.Path), string(test.Path))
 	}
 
 	if string(constraint.Value) != string(test.Value) {
-		return fmt.Errorf("object<%s> contraint value<%s> not expected<%s>",
+		return fmt.Errorf("object<%s> constraint value<%s> not expected<%s>",
 			object, string(constraint.Value), string(test.Value))
 	}
 

--- a/session/autocharthandler.go
+++ b/session/autocharthandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -60,7 +61,7 @@ func (instance *AutoChartInstance) handleAutoChart(sessionState *State, actionSt
 
 	// get generated layout
 	var generatedLayout json.RawMessage
-	generatedLayoutPath := senseobjdef.NewDataPath(GeneratedPropertiesPath) // Path same as for properties
+	generatedLayoutPath := helpers.NewDataPath(GeneratedPropertiesPath) // Path same as for properties
 	rawGeneratedLayout, errDataPath := generatedLayoutPath.Lookup(rawLayout)
 	if errDataPath != nil {
 		actionState.AddErrors(errors.Wrapf(errDataPath, "Failed to get generated layout for autochart<%s>", autochartGen.GenericId))
@@ -107,7 +108,7 @@ func (instance *AutoChartInstance) handleAutoChart(sessionState *State, actionSt
 	instance.ObjectDef = &senseobjdef.ObjectDef{
 		DataDef: senseobjdef.DataDef{
 			Type: objectDef.DataDef.Type,
-			Path: senseobjdef.DataPath(fmt.Sprintf("%s%s", GeneratedPropertiesPath, objectDef.DataDef.Path)),
+			Path: helpers.DataPath(fmt.Sprintf("%s%s", GeneratedPropertiesPath, objectDef.DataDef.Path)),
 		},
 	}
 
@@ -162,7 +163,7 @@ func (instance *AutoChartInstance) SetObjectDefData(objDefData []senseobjdef.Dat
 			for i, c := range data.Constraints {
 				// de-reference pointer and update path in constraint
 				data.Constraints[i] = &senseobjdef.Constraint{
-					Path:     senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path)),
+					Path:     helpers.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path)),
 					Value:    c.Value,
 					Required: c.Required,
 				}
@@ -220,7 +221,7 @@ func getRawLayoutAndGeneratedProperties(sessionState *State, actionState *action
 		}
 
 		// Get generated properties
-		generatedPropPath := senseobjdef.NewDataPath(GeneratedPropertiesPath)
+		generatedPropPath := helpers.NewDataPath(GeneratedPropertiesPath)
 		rawGeneratedProp, errDataPath := generatedPropPath.Lookup(rawAutoChartProperties)
 		if errDataPath != nil {
 			return errors.Wrapf(errDataPath, "Failed to get generated properties for autochart<%s>", autochartGen.GenericId)

--- a/session/autocharthandler.go
+++ b/session/autocharthandler.go
@@ -159,8 +159,13 @@ func (instance *AutoChartInstance) SetObjectDefData(objDefData []senseobjdef.Dat
 		data.Requests = requests
 
 		if data.Constraints != nil {
-			for _, c := range data.Constraints {
-				c.Path = senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path))
+			for i, c := range data.Constraints {
+				// de-reference pointer and update path in constraint
+				data.Constraints[i] = &senseobjdef.Constraint{
+					Path:     senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path)),
+					Value:    c.Value,
+					Required: c.Required,
+				}
 			}
 		}
 		instance.ObjectDef.Data = append(instance.ObjectDef.Data, data)

--- a/session/autocharthandler.go
+++ b/session/autocharthandler.go
@@ -159,11 +159,8 @@ func (instance *AutoChartInstance) SetObjectDefData(objDefData []senseobjdef.Dat
 		data.Requests = requests
 
 		if data.Constraint != nil {
-			// de-reference pointer and update path in constraint
-			data.Constraint = &senseobjdef.Constraint{
-				Path:     senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, data.Constraint.Path)),
-				Value:    data.Constraint.Value,
-				Required: data.Constraint.Required,
+			for _, c := range data.Constraint {
+				c.Path = senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path))
 			}
 		}
 		instance.ObjectDef.Data = append(instance.ObjectDef.Data, data)

--- a/session/autocharthandler.go
+++ b/session/autocharthandler.go
@@ -158,8 +158,8 @@ func (instance *AutoChartInstance) SetObjectDefData(objDefData []senseobjdef.Dat
 		}
 		data.Requests = requests
 
-		if data.Constraint != nil {
-			for _, c := range data.Constraint {
+		if data.Constraints != nil {
+			for _, c := range data.Constraints {
 				c.Path = senseobjdef.DataPath(fmt.Sprint(GeneratedPropertiesPath, c.Path))
 			}
 		}

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"math"
 	"sync"
 
@@ -186,11 +187,11 @@ func SetObjectDataAndEvents(sessionState *State, actionState *action.State, obj 
 }
 
 func SetChildList(rawLayout json.RawMessage, obj *enigmahandlers.Object) error {
-	childDataPath := senseobjdef.NewDataPath("qChildList")
+	childDataPath := helpers.NewDataPath("qChildList")
 
 	rawChildren, err := childDataPath.Lookup(rawLayout)
 	switch errors.Cause(err).(type) {
-	case senseobjdef.NoDataFound:
+	case helpers.NoDataFound:
 		return nil //object has no children
 	case nil:
 		//object has children
@@ -208,11 +209,11 @@ func SetChildList(rawLayout json.RawMessage, obj *enigmahandlers.Object) error {
 }
 
 func SetChildren(rawLayout json.RawMessage, obj *enigmahandlers.Object) error {
-	childDataPath := senseobjdef.NewDataPath("children")
+	childDataPath := helpers.NewDataPath("children")
 
 	rawChildren, err := childDataPath.Lookup(rawLayout)
 	switch errors.Cause(err).(type) {
-	case senseobjdef.NoDataFound:
+	case helpers.NoDataFound:
 		return nil //object has no children
 	case nil:
 		//object has children
@@ -229,7 +230,7 @@ func SetChildren(rawLayout json.RawMessage, obj *enigmahandlers.Object) error {
 	return nil
 }
 
-func SetListObject(rawLayout json.RawMessage, obj *enigmahandlers.Object, path senseobjdef.DataPath) error {
+func SetListObject(rawLayout json.RawMessage, obj *enigmahandlers.Object, path helpers.DataPath) error {
 	rawListObject, err := path.Lookup(rawLayout)
 	if err != nil {
 		return errors.Wrap(err, "error getting listObject")
@@ -244,7 +245,7 @@ func SetListObject(rawLayout json.RawMessage, obj *enigmahandlers.Object, path s
 	return nil
 }
 
-func SetHyperCube(rawLayout json.RawMessage, obj *enigmahandlers.Object, path senseobjdef.DataPath) error {
+func SetHyperCube(rawLayout json.RawMessage, obj *enigmahandlers.Object, path helpers.DataPath) error {
 	rawHyperCube, err := path.Lookup(rawLayout)
 	if err != nil {
 		return errors.Wrap(err, "error getting hypercube")


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated


**Squash commit message**

Fix an issue where some linecharts yield a hypercube error

**Info**

Change lookup for whether a linechart is considered continuous, and therefore needs to be fetched with GetHyperCubeContinuousData.

Change constraint to be an array, where each constraint needs to be fulfilled. Throw an unmarshal error if an object definition file of the old format is used.
