### PR TITLE
Enable doccompiler to partially overload docentry

### DIFF
--- a/generatedocs/pkg/doccompiler/compile.go
+++ b/generatedocs/pkg/doccompiler/compile.go
@@ -221,10 +221,20 @@ func mergeGroups(baseGroups []common.GroupsEntry, newGroups []common.GroupsEntry
 
 func overloadDocMap(baseMap, newMap map[string]common.DocEntry, baseNames *[]string, newNames []string) {
 	if baseNames != nil {
-		*baseNames = append(*baseNames, newNames...)
+		for _, newName := range newNames {
+			if _, ok := baseMap[newName]; !ok {
+				*baseNames = append(*baseNames, newName)
+			}
+		}
 	}
-	for k, v := range newMap {
-		baseMap[k] = v
+	for newName, newDocEntry := range newMap {
+		if newDocEntry.Description == "" {
+			newDocEntry.Description = baseMap[newName].Description
+		}
+		if newDocEntry.Examples == "" {
+			newDocEntry.Examples = baseMap[newName].Examples
+		}
+		baseMap[newName] = newDocEntry
 	}
 }
 


### PR DESCRIPTION
**Checklist**

- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)

**Squash commit message**

Enable doccompiler to partially overload docentry

This makes it possible to of overload just one of examples.md or description.md when generating documentation.

**Info**

