### PR TITLE
add pooled buffers

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -1,7 +1,6 @@
 package connection
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,6 +13,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/enummap"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"github.com/qlik-oss/gopherciser/session"
 	"github.com/qlik-oss/gopherciser/users"
 )
@@ -276,7 +276,8 @@ func (connectionSettings *ConnectionSettings) addReqHeaders(data *users.User, he
 			continue
 		}
 
-		buf := bytes.NewBuffer(nil)
+		buf := helpers.GlobalBufferPool.Get()
+		defer helpers.GlobalBufferPool.Put(buf)
 		if err := tmpl.Execute(buf, data); err != nil {
 			return header, errors.Wrapf(err, "failed executing %s template", tmpl.Name())
 		}

--- a/helpers/BufferPool.go
+++ b/helpers/BufferPool.go
@@ -1,0 +1,31 @@
+package helpers
+
+import (
+	"bytes"
+	"sync"
+)
+
+type (
+	BufferPool struct {
+		pool sync.Pool
+	}
+)
+
+var GlobalBufferPool = NewBufferPool()
+
+func NewBufferPool() *BufferPool {
+	return &BufferPool{sync.Pool{New: newBuffer}}
+}
+
+func newBuffer() interface{} {
+	return bytes.NewBuffer(nil)
+}
+
+func (bp *BufferPool) Get() *bytes.Buffer {
+	return bp.pool.Get().(*bytes.Buffer)
+}
+
+func (bp *BufferPool) Put(buf *bytes.Buffer) {
+	buf.Reset()
+	bp.pool.Put(buf)
+}

--- a/scenario/uploaddata.go
+++ b/scenario/uploaddata.go
@@ -1,7 +1,6 @@
 package scenario
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -116,7 +115,8 @@ func (settings UploadDataSettings) Execute(
 		}
 	}()
 
-	body := &bytes.Buffer{}
+	body := helpers.GlobalBufferPool.Get()
+	defer helpers.GlobalBufferPool.Put(body)
 	writer := multipart.NewWriter(body)
 
 	// Then create the binary multipart field

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -620,7 +619,8 @@ func (state *State) ReplaceSessionVariablesWithLocalData(input *SyncedTemplate, 
 		return "", errors.New("nil Session on LogEntry")
 	}
 
-	buf := bytes.NewBuffer(nil)
+	buf := helpers.GlobalBufferPool.Get()
+	defer helpers.GlobalBufferPool.Put(buf)
 	if err := input.Execute(buf, state.GetSessionVariable(localData)); err != nil {
 		return "", errors.Wrap(err, "failed to execute variables template")
 	}

--- a/session/syncedTemplate.go
+++ b/session/syncedTemplate.go
@@ -1,7 +1,6 @@
 package session
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +11,7 @@ import (
 	uuid "github.com/google/uuid"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
+	"github.com/qlik-oss/gopherciser/helpers"
 )
 
 type (
@@ -117,7 +117,8 @@ func (syn *SyncedTemplate) String() string {
 
 // ReplaceWithoutSessionVariables execute template without session variables - only use if we do not have a session
 func (input *SyncedTemplate) ReplaceWithoutSessionVariables(data interface{}) (string, error) {
-	buf := bytes.NewBuffer(nil)
+	buf := helpers.GlobalBufferPool.Get()
+	defer helpers.GlobalBufferPool.Put(buf)
 	if err := input.Execute(buf, data); err != nil {
 		return "", errors.Wrap(err, "failed to execute variables template")
 	}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Use a pool to decrease allocation of memory when using buffers.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
![image](https://user-images.githubusercontent.com/16015083/102621935-9ba61f80-4140-11eb-9e65-de51175c1c15.png)

Also tried using jsoniter "fastest" mode, but made basically no difference to mem or cpu.