### PR TITLE
Add option to apply selections only in `applybookmark` action.

### DIFF
--- a/scenario/applybookmark.go
+++ b/scenario/applybookmark.go
@@ -15,6 +15,7 @@ type (
 	//ApplyBookmarkSettings apply bookmark settings
 	ApplyBookmarkSettings struct {
 		BookMarkSettings
+		SelectionsOnly bool `json:"selectionsonly"`
 	}
 
 	bmSearchTerm int
@@ -85,13 +86,13 @@ func (settings ApplyBookmarkSettings) Execute(sessionState *session.State, actio
 		return // An error occurred
 	}
 
-	if sheetID != "" {
+	if sheetID != "" && !settings.SelectionsOnly {
 		sessionState.LogEntry.LogDebug(fmt.Sprint("ApplyBookmark: Change sheet to ", sheetID))
 		(&ChangeSheetSettings{
 			ID: sheetID,
 		}).Execute(sessionState, actionState, connectionSettings, label, reset)
 	}
-	actionState.Details = fmt.Sprintf("%v;%s", sheetID != "", sheetID) // log details in results as {Has sheet};{Sheet ID}
+	actionState.Details = fmt.Sprintf("%v;%s;%v", sheetID != "", sheetID, settings.SelectionsOnly) // log details in results as {Has sheet};{Sheet ID};{Apply Selections Only}
 
 	sessionState.Wait(actionState)
 }

--- a/scenario/applybookmark_test.go
+++ b/scenario/applybookmark_test.go
@@ -1,0 +1,46 @@
+package scenario_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/qlik-oss/gopherciser/scenario"
+	"github.com/qlik-oss/gopherciser/session"
+)
+
+func TestUnmarshalApplyBookmark(t *testing.T) {
+	title, err := session.NewSyncedTemplate("hasTitle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedBM := scenario.ApplyBookmarkSettings{
+		BookMarkSettings: scenario.BookMarkSettings{
+			Title: *title,
+			ID:    "hasid",
+		},
+		SelectionsOnly: true,
+	}
+
+	raw := []byte(`{
+		"title": "` + title.String() + `",
+		"id": "` + expectedBM.ID + `",
+		"selectionsonly" : ` + fmt.Sprintf("%v", expectedBM.SelectionsOnly) + `
+}`)
+	var bm scenario.ApplyBookmarkSettings
+	if err := json.Unmarshal(raw, &bm); err != nil {
+		t.Fatal(err)
+	}
+
+	if expectedBM.Title.String() != bm.Title.String() {
+		t.Errorf("unexpected title<%s>, expected<%s>", bm.Title.String(), expectedBM.Title.String())
+	}
+
+	if expectedBM.ID != bm.ID {
+		t.Errorf("unexpected ID<%s>, expected<%s>", bm.ID, expectedBM.ID)
+	}
+
+	if expectedBM.SelectionsOnly != bm.SelectionsOnly {
+		t.Errorf("unexpected selectionsonly<%v>, expected<%v>", bm.SelectionsOnly, expectedBM.SelectionsOnly)
+	}
+}

--- a/scenario/clickactionbutton.go
+++ b/scenario/clickactionbutton.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/qlik-oss/gopherciser/helpers"
 	"strconv"
 	"strings"
+
+	"github.com/qlik-oss/gopherciser/helpers"
 
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/enigma-go"
@@ -265,6 +266,7 @@ func (buttonAction *buttonAction) execute(sessionState *session.State, actionSta
 			BookMarkSettings{
 				ID: buttonAction.Bookmark,
 			},
+			false,
 		}
 
 	case clearAllSelections:

--- a/scenario/clickactionbutton.go
+++ b/scenario/clickactionbutton.go
@@ -266,7 +266,7 @@ func (buttonAction *buttonAction) execute(sessionState *session.State, actionSta
 			BookMarkSettings{
 				ID: buttonAction.Bookmark,
 			},
-			false,
+			true,
 		}
 
 	case clearAllSelections:


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

* Add option to apply selections only in `applybookmark` action.
* Bugfix: Change click button apply bookmark action to not change sheet.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
