### PR TITLE
Make sure ws connect context has a deadline

### DIFF
--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -43,7 +43,11 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 			}
 		}
 
-		if err := sense.Connect(sessionState.BaseContext(), url, header, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
+		// Connect
+		ctx, cancel := sessionState.ContextWithTimeout(sessionState.BaseContext())
+		defer cancel()
+
+		if err := sense.Connect(ctx, url, header, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
 			return appGUID, errors.Wrap(err, "Failed connecting to sense server")
 		}
 

--- a/wsdialer/wsdialer.go
+++ b/wsdialer/wsdialer.go
@@ -147,6 +147,12 @@ func New(url *neturl.URL, httpHeader http.Header, cookieJar http.CookieJar, time
 
 // Dial new websocket connection
 func (dialer *WsDialer) Dial(ctx context.Context) error {
+	_, hasDeadline := ctx.Deadline()
+	if !hasDeadline {
+		// make sure we have a timeout on connect
+		dialer.Dialer.Timeout = time.Minute
+	}
+
 	var err error
 	dialer.Conn, _ /*br*/, _ /*hs*/, err = dialer.Dialer.Dial(ctx, dialer.url.String())
 	return errors.WithStack(err)


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

- `wsconnect` version of websocket connection did not, as more correctly done by the `jwtconnection` version, set a deadline on the connect context.
- Adding a default 1 minute deadline for any custom connect functions which hasn't a deadline in context when gopherciser is used as a library.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
