### PR TITLE
add /debug/pprof endpoint when running tool with --metrics flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "net/http/pprof"
+
 	"github.com/qlik-oss/gopherciser/cmd"
 )
 


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Add /debug/pprof endpoint to tool when running a http listener (currrently done with the --metrics flag) for debugging purposes. Should not affect anything other then slightly bigger binary unless listener is running and endpoint accessed.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
