### PR TITLE
Bugfix: Windows binary hanging in cygwin

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -40,12 +40,12 @@ type (
 )
 
 var (
-	metricsPort        int
-	metricsAddress     string
-	metricsLabel       string
-	metricsGroupings   []string
-	profTyp            string
-	objDefFile         string
+	metricsPort      int
+	metricsAddress   string
+	metricsLabel     string
+	metricsGroupings []string
+	profTyp          string
+	objDefFile       string
 )
 
 // *** Custom errors ***
@@ -312,12 +312,4 @@ func resolveSummaryType() (config.SummaryType, error) {
 		}
 		return config.SummaryType(i), nil
 	}
-}
-
-func hasPipe() (bool, error) {
-	fileInfo, err := os.Stdin.Stat()
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-	return fileInfo.Mode() & os.ModeCharDevice == 0, nil
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -138,11 +138,9 @@ func overrideScriptValues(cfgJSON []byte) ([]byte, []string, error) {
 			// golang can't detect char devices properly in cygwin, handle this by closing stdin after a second
 			readingCtx, done := context.WithCancel(context.Background())
 			if runtime.GOOS == "windows" {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-				defer cancel()
 				go func() {
 					select {
-					case <-ctx.Done():
+					case <-time.After(time.Second):
 						os.Stdin.Close()
 					case <-readingCtx.Done():
 					}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -67,7 +67,7 @@ func unmarshalConfigFile() (*config.Config, error) {
 			return nil, errors.Wrap(err, "error reading config from stdin")
 		}
 		if !hasPipe {
-			return  nil, errors.New("no config file and nothing on stdin")
+			return nil, errors.New("no config file and nothing on stdin")
 		}
 
 		scanner := bufio.NewScanner(os.Stdin)
@@ -125,7 +125,7 @@ func overrideScriptValues(cfgJSON []byte) ([]byte, []string, error) {
 	} else if cfgFile != "" { // if cfg file has been pointed to, but has stdin piped, assume it's overrides
 		hasPipe, err := hasPipe()
 		if err != nil {
-			return nil, nil,  errors.Wrap(err, "error reading overrides from stdin")
+			return nil, nil, errors.Wrap(err, "error reading overrides from stdin")
 		}
 		if hasPipe {
 			if scriptOverrides == nil {
@@ -229,4 +229,12 @@ func PrintOverrides(overrides []string) {
 		os.Stderr.WriteString(override)
 	}
 	os.Stderr.WriteString("========================\n")
+}
+
+func hasPipe() (bool, error) {
+	fileInfo, err := os.Stdin.Stat()
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+	return fileInfo.Mode()&os.ModeCharDevice == 0, nil
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Add code to handle expected data on stdin when running in cygwin since chardevices are not detected properly by golang.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
