### PR TITLE
"stringbools" can sometimes be sent as "0" instead of "False"

### DIFF
--- a/helpers/stringbool.go
+++ b/helpers/stringbool.go
@@ -20,6 +20,7 @@ func (sb *StringBool) UnmarshalJSON(arg []byte) error {
 
 	switch strings.ToLower(s) {
 	case "false":
+	case "0":
 		*sb = false
 	default:
 		*sb = true


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

string "boolean" from engine under certain conditions sent as "0" instead of "False".

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
