### PR TITLE
Add prometheus metrics for API calls

### DIFF
--- a/buildmetrics/buildmetrics.go
+++ b/buildmetrics/buildmetrics.go
@@ -27,19 +27,20 @@ func getLabel(action string, label string) string {
 }
 
 // ReportApiResult reports the duration for a specific API path and response code
-func ReportApiResult(path, method string, responseCode int, duration time.Duration) {
+func ReportApiResult(action, label, path, method string, responseCode int, duration time.Duration) {
 	if metricEnabled() {
+		actionlabel := getLabel(action, label)
 		resultString := strconv.Itoa(responseCode)
-		metrics.ApiCallDuration.WithLabelValues(path, method, resultString).Observe(duration.Seconds())
-		metrics.ApiCallDurationQuantile.WithLabelValues(path, method, resultString).Observe(duration.Seconds())
+		metrics.ApiCallDuration.WithLabelValues(actionlabel, path, method, resultString).Observe(duration.Seconds())
+		metrics.ApiCallDurationQuantile.WithLabelValues(actionlabel, path, method, resultString).Observe(duration.Seconds())
 	}
 }
 
 // ReportSuccess is invoked when a simulated user action is successfully completed.
 // This then updates Prometheus metrics correlating to this (ReponseTimes | Latency | success counter for an action)
 func ReportSuccess(action string, label string, time float64) {
-	actionlabel := getLabel(action, label)
 	if metricEnabled() {
+		actionlabel := getLabel(action, label)
 		metrics.GopherResponseTimes.WithLabelValues(actionlabel).Observe(time)
 		metrics.GopherActionLatencyHist.WithLabelValues(actionlabel).Observe(time)
 		metrics.GopherActions.WithLabelValues("success", actionlabel).Inc()
@@ -49,8 +50,8 @@ func ReportSuccess(action string, label string, time float64) {
 // ReportFailure is invoked when a simulated user action fails.
 // This then updates Prometheus metrics correlating to this (Failure counter for an action)
 func ReportFailure(action string, label string) {
-	actionlabel := getLabel(action, label)
 	if metricEnabled() {
+		actionlabel := getLabel(action, label)
 		metrics.GopherActions.WithLabelValues("failure", actionlabel).Inc()
 	}
 }
@@ -58,8 +59,8 @@ func ReportFailure(action string, label string) {
 // ReportError is invoked when an error occurs in execution. A user action can in theory have many errors.
 // This then updates Prometheus metrics correlating to this (Error counter)
 func ReportError(action string, label string) {
-	actionlabel := getLabel(action, label)
 	if metricEnabled() {
+		actionlabel := getLabel(action, label)
 		metrics.GopherErrors.WithLabelValues(actionlabel).Inc()
 	}
 }
@@ -67,8 +68,8 @@ func ReportError(action string, label string) {
 // ReportWarning is invoked when an warning occurs in execution. A user action can in theory have many warnings.
 // This then updates Prometheus metrics correlating to this (Warning counter)
 func ReportWarning(action string, label string) {
-	actionlabel := getLabel(action, label)
 	if metricEnabled() {
+		actionlabel := getLabel(action, label)
 		metrics.GopherWarnings.WithLabelValues(actionlabel).Inc()
 	}
 }

--- a/buildmetrics/buildmetrics.go
+++ b/buildmetrics/buildmetrics.go
@@ -27,11 +27,11 @@ func getLabel(action string, label string) string {
 }
 
 // ReportApiResult reports the duration for a specific API path and response code
-func ReportApiResult(path string, responseCode int, duration time.Duration) {
+func ReportApiResult(path, method string, responseCode int, duration time.Duration) {
 	if metricEnabled() {
 		resultString := strconv.Itoa(responseCode)
-		metrics.ApiCallDuration.WithLabelValues(path, resultString).Observe(duration.Seconds())
-		metrics.ApiCallDurationQuantile.WithLabelValues(path, resultString).Observe(duration.Seconds())
+		metrics.ApiCallDuration.WithLabelValues(path, method, resultString).Observe(duration.Seconds())
+		metrics.ApiCallDurationQuantile.WithLabelValues(path, method, resultString).Observe(duration.Seconds())
 	}
 }
 

--- a/buildmetrics/buildmetrics.go
+++ b/buildmetrics/buildmetrics.go
@@ -4,6 +4,8 @@ package buildmetrics
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	"github.com/qlik-oss/gopherciser/metrics"
 )
@@ -22,6 +24,15 @@ func getLabel(action string, label string) string {
 		return label
 	}
 	return action
+}
+
+// ReportApiResult reports the duration for a specific API path and response code
+func ReportApiResult(path string, responseCode int, duration time.Duration) {
+	if metricEnabled() {
+		resultString := strconv.Itoa(responseCode)
+		metrics.ApiCallDuration.WithLabelValues(path, resultString).Observe(duration.Seconds())
+		metrics.ApiCallDurationQuantile.WithLabelValues(path, resultString).Observe(duration.Seconds())
+	}
 }
 
 // ReportSuccess is invoked when a simulated user action is successfully completed.

--- a/buildmetrics/buildmetrics_js.go
+++ b/buildmetrics/buildmetrics_js.go
@@ -4,6 +4,7 @@ package buildmetrics
 
 import (
 	"context"
+	"time"
 )
 
 var (
@@ -20,6 +21,11 @@ func getLabel(action string, label string) string {
 		return label
 	}
 	return action
+}
+
+// ReportApiResult reports the duration for a specific API path and response code
+func ReportApiResult(path string, responseCode int, duration time.Duration) {
+	return
 }
 
 // ReportSuccess shall never report Prometheus metrics for WASM/JS builds as it is not supported nor wanted, hence "return"

--- a/metrics/custom.go
+++ b/metrics/custom.go
@@ -15,7 +15,7 @@ var ApiCallDuration = prometheus.NewHistogramVec(
 		Help:    "A histogram of HTTP request durations.",
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.5, 1., 2.0, 2.5, 5., 10.},
 	},
-	[]string{"path", "method", "status_code"},
+	[]string{"action", "path", "method", "status_code"},
 )
 
 // ApiCallDurationQuantile summary for API call duration
@@ -25,7 +25,7 @@ var ApiCallDurationQuantile = prometheus.NewSummaryVec(
 		Help:       "A summary of HTTP request durations",
 		Objectives: map[float64]float64{0.1: 0.1, 0.5: 0.05, 0.95: 0.01, 0.99: 0.001, 0.999: 0.0001},
 	},
-	[]string{"path", "method", "status_code"},
+	[]string{"action", "path", "method", "status_code"},
 )
 
 // GopherActions action counter

--- a/metrics/custom.go
+++ b/metrics/custom.go
@@ -8,6 +8,26 @@ const (
 	promNS = "gopherciser"
 )
 
+// ApiCallDuration histogram for API call duration
+var ApiCallDuration = prometheus.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "api_request_duration_seconds",
+		Help:    "A histogram of HTTP request durations.",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.25, 0.5, 1., 2.0, 2.5, 5., 10.},
+	},
+	[]string{"path", "method", "status_code"},
+)
+
+// ApiCallDurationQuantile summary for API call duration
+var ApiCallDurationQuantile = prometheus.NewSummaryVec(
+	prometheus.SummaryOpts{
+		Name:       "api_request_duration_quantiles_seconds",
+		Help:       "A summary of HTTP request durations",
+		Objectives: map[float64]float64{0.1: 0.1, 0.5: 0.05, 0.95: 0.01, 0.99: 0.001, 0.999: 0.0001},
+	},
+	[]string{"path", "method", "status_code"},
+)
+
 // GopherActions action counter
 var GopherActions = prometheus.NewCounterVec(
 	prometheus.CounterOpts{

--- a/metrics/transport.go
+++ b/metrics/transport.go
@@ -18,6 +18,8 @@ import (
 )
 
 func setupMetrics(actions []string) error {
+	prometheus.MustRegister(ApiCallDuration)
+	prometheus.MustRegister(ApiCallDurationQuantile)
 	prometheus.MustRegister(GopherActions)
 	prometheus.MustRegister(GopherWarnings)
 	prometheus.MustRegister(GopherErrors)
@@ -27,7 +29,15 @@ func setupMetrics(actions []string) error {
 	prometheus.MustRegister(GopherActionLatencyHist)
 	prometheus.MustRegister(BuildInfo)
 
-	err := gopherRegistry.Register(GopherActions)
+	err := gopherRegistry.Register(ApiCallDuration)
+	if err != nil {
+		return err
+	}
+	err = gopherRegistry.Register(ApiCallDurationQuantile)
+	if err != nil {
+		return err
+	}
+	err = gopherRegistry.Register(GopherActions)
 	if err != nil {
 		return err
 	}

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/qlik-oss/gopherciser/buildmetrics"
+
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/enigma-go"
 	"github.com/qlik-oss/gopherciser/action"
@@ -636,6 +638,11 @@ func (transport *Transport) RoundTrip(req *http.Request) (*http.Response, error)
 	}
 
 	recTS := time.Now()
+
+	apiPath := apiCallFromPath(req.URL.Path)
+	if apiPath != "" {
+		buildmetrics.ReportApiResult(apiPath, resp.StatusCode, recTS.Sub(sentTS))
+	}
 
 	respSize := int64(0)
 	if resp.ContentLength > 0 {

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -641,7 +641,7 @@ func (transport *Transport) RoundTrip(req *http.Request) (*http.Response, error)
 
 	apiPath := apiCallFromPath(req.URL.Path)
 	if apiPath != "" {
-		buildmetrics.ReportApiResult(apiPath, resp.StatusCode, recTS.Sub(sentTS))
+		buildmetrics.ReportApiResult(apiPath, req.Method, resp.StatusCode, recTS.Sub(sentTS))
 	}
 
 	respSize := int64(0)

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -709,3 +709,18 @@ func contentIsBinary(header http.Header) bool {
 	}
 	return false
 }
+
+const apiSeparator = "api/v1/"
+
+func apiCallFromPath(path string) string {
+	splitApiV1 := strings.Split(path, apiSeparator)
+	if len(splitApiV1) < 2 {
+		return "" // No api call found in path
+	}
+	apiCall := splitApiV1[1]
+	splitSlash := strings.Split(apiCall, "/")
+	if len(splitSlash) < 1 {
+		return "" // Nothing after apiSeparator (which is weird)
+	}
+	return fmt.Sprintf("%s%s", apiSeparator, splitSlash[0])
+}

--- a/session/resthandler_test.go
+++ b/session/resthandler_test.go
@@ -62,3 +62,14 @@ func TestReqOptions(t *testing.T) {
 		t.Errorf("Default options changed when modifying instance returned from DefaultReqOptions()")
 	}
 }
+
+func TestApiExtract(t *testing.T) {
+	test1 := "http://myserver:9565/api/v1/items/abc123/action"
+	test2 := "http://myserver:9565/api/dcaas"
+	test3 := "http://myserver.com/api/v1/evaluation"
+
+	assert.Equal(t, "api/v1/items", apiCallFromPath(test1))
+	assert.Equal(t, "", apiCallFromPath(test2))
+	assert.Equal(t, "api/v1/evaluation", apiCallFromPath(test3))
+
+}

--- a/session/resthandler_test.go
+++ b/session/resthandler_test.go
@@ -63,7 +63,7 @@ func TestReqOptions(t *testing.T) {
 	}
 }
 
-func TestApiExtract(t *testing.T) {
+func TestApiCallFromPath(t *testing.T) {
 	test1 := "api/v1/items/abc123/action"
 	test2 := "api/dcaas"
 	test3 := "api/v1/evaluation"
@@ -71,5 +71,4 @@ func TestApiExtract(t *testing.T) {
 	assert.Equal(t, "api/v1/items", apiCallFromPath(test1))
 	assert.Equal(t, "", apiCallFromPath(test2))
 	assert.Equal(t, "api/v1/evaluation", apiCallFromPath(test3))
-
 }

--- a/session/resthandler_test.go
+++ b/session/resthandler_test.go
@@ -64,9 +64,9 @@ func TestReqOptions(t *testing.T) {
 }
 
 func TestApiExtract(t *testing.T) {
-	test1 := "http://myserver:9565/api/v1/items/abc123/action"
-	test2 := "http://myserver:9565/api/dcaas"
-	test3 := "http://myserver.com/api/v1/evaluation"
+	test1 := "api/v1/items/abc123/action"
+	test2 := "api/dcaas"
+	test3 := "api/v1/evaluation"
 
 	assert.Equal(t, "api/v1/items", apiCallFromPath(test1))
 	assert.Equal(t, "", apiCallFromPath(test2))


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Add a prometheus SummaryVec and Histogram for duration per HTTP-level API calls including path, method and status code. Limitation: only aggregates results to one level after "api/v1", e.g.

GET https://test:9001/api/v1/evaluations -> "api/v1/evaluations", GET, 200
POST https://test:9001/api/v1/evaluations/abc123 -> "api/v1/evaluations", POST, 201
GET https://test:9001/api/dcaas -> no reporting
