### PR TITLE
Make elasticmoveapp navigate to space by default

### DIFF
--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -219,6 +219,7 @@ Apply a bookmark in the current app.
 
 * `title`: Name of the bookmark (supports the use of [variables](#session_variables)).
 * `id`: ID of the bookmark.
+* `selectionsonly`: *Missing documentation*
 
 ### Example
 
@@ -1808,6 +1809,8 @@ Move an app from its existing space into the specified destination space.
 * `filename`: Path to a file in which each line represents an app. Used with `appmode` set to `randomnamefromfile`, `randomguidfromfile`, `roundnamefromfile` or `roundguidfromfile`.
 * `destinationspaceid`: Specify destination space by ID.
 * `destinationspacename`: Specify destination space by name.
+* `keepcurrent`: Keep the current artifact map when moving to target space at the end of `elasticmoveapp`. Defaults to `false`. Current artifact map is always kept when `donotnavigatetospace` is set.
+* `donotnavigatetospace`: Do not navigate to target space after moving app. Defaults to `false`.
 
 ### Example
 

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -394,6 +394,12 @@
     "elastichubsearch.queryfile": [
         "(optional) File from which to read a query (in case of `fromfile` as source)."
     ],
+    "elasticmoveapp.keepcurrent": [
+        "Keep the current artifact map when moving to target space at the end of `elasticmoveapp`. Defaults to `false`. Current artifact map is always kept when `donotnavigatetospace` is set."
+    ],
+    "elasticmoveapp.donotnavigatetospace": [
+        "Do not navigate to target space after moving app. Defaults to `false`."
+    ],
     "elasticreload.pollingoff": [
         "DEPRECATED"
     ],

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -320,6 +320,8 @@ var (
 		"elastichubsearch.queryfile":                      {"(optional) File from which to read a query (in case of `fromfile` as source)."},
 		"elastichubsearch.querysource":                    {"", "`string`: The query is provided as a string specified by `query`.", "`fromfile`: The queries are read from the file specified by `queryfile`, where each line represents a query."},
 		"elastichubsearch.searchfor":                      {"", "`collections`: Search for collections only.", "`apps`: Search for apps only.", "`both`: Search for both collections and apps."},
+		"elasticmoveapp.donotnavigatetospace":             {"Do not navigate to target space after moving app. Defaults to `false`."},
+		"elasticmoveapp.keepcurrent":                      {"Keep the current artifact map when moving to target space at the end of `elasticmoveapp`. Defaults to `false`. Current artifact map is always kept when `donotnavigatetospace` is set."},
 		"elasticpublishapp.cleartags":                     {"Publish the app without its original tags."},
 		"elasticreload.log":                               {"DEPRECATED"},
 		"elasticreload.pollingoff":                        {"DEPRECATED"},

--- a/scenario/elasticmoveapp.go
+++ b/scenario/elasticmoveapp.go
@@ -17,6 +17,11 @@ type (
 	ElasticMoveAppSettings struct {
 		session.AppSelection
 		DestinationSpace
+		NavigateToSpaceSettings
+	}
+
+	NavigateToSpaceSettings struct {
+		DoNotNavigateToSpace bool `json:"donotnavigatetospace" displayname:"Navigate to space" doc-key:"elasticmoveapp.donotnavigatetospace"`
 	}
 
 	DestinationSpace struct {
@@ -29,6 +34,9 @@ type (
 
 // UnmarshalJSON unmarshals ElasticMoveAppSettings from JSON
 func (settings *ElasticMoveAppSettings) UnmarshalJSON(arg []byte) error {
+	if err := jsonit.Unmarshal(arg, &settings.NavigateToSpaceSettings); err != nil {
+		return errors.Wrapf(err, "failed to unmarshal action<%s>", ActionElasticMoveApp)
+	}
 	var actionCore DestinationSpace
 	if err := jsonit.Unmarshal(arg, &actionCore); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal action<%s>", ActionElasticMoveApp)
@@ -37,8 +45,8 @@ func (settings *ElasticMoveAppSettings) UnmarshalJSON(arg []byte) error {
 	if err := jsonit.Unmarshal(arg, &appSelectCore); err != nil {
 		return errors.Wrapf(err, "failed to unmarshal action<%s>", ActionElasticMoveApp)
 	}
-	(*settings).DestinationSpace = actionCore
-	(*settings).AppSelection = appSelectCore
+	settings.DestinationSpace = actionCore
+	settings.AppSelection = appSelectCore
 	return nil
 }
 
@@ -92,6 +100,18 @@ func (settings ElasticMoveAppSettings) Execute(sessionState *session.State, acti
 	}
 	if putApp.ResponseStatusCode != http.StatusOK {
 		actionState.AddErrors(errors.Errorf("unexpected response code <%d> when putting app in new space: %s", putApp.ResponseStatusCode, putApp.ResponseBody))
+	}
+	settings.NavigateToSpace(sessionState, actionState, host, destSpace.ID)
+}
+
+func (settings NavigateToSpaceSettings) NavigateToSpace(sessionState *session.State, actionState *action.State, host string, spaceID string) {
+	if settings.DoNotNavigateToSpace {
+		return
+	}
+	_, err := sessionState.Rest.GetSync(fmt.Sprintf("%s/api/v1/spaces/%s/assignments?limit=100", host, spaceID), actionState, sessionState.LogEntry, nil)
+	if err != nil {
+		actionState.AddErrors(errors.Wrap(err, "failed during navigate to space"))
+		return
 	}
 }
 

--- a/scenario/elasticmoveapp.go
+++ b/scenario/elasticmoveapp.go
@@ -21,6 +21,8 @@ type (
 	}
 
 	NavigateToSpaceSettings struct {
+		// KeepCurrent artifact map and fill with results from explore action
+		KeepCurrent          bool `json:"keepcurrent" displayname:"Keep current" doc-key:"elasticmoveapp.keepcurrent"`
 		DoNotNavigateToSpace bool `json:"donotnavigatetospace" displayname:"Navigate to space" doc-key:"elasticmoveapp.donotnavigatetospace"`
 	}
 
@@ -102,17 +104,26 @@ func (settings ElasticMoveAppSettings) Execute(sessionState *session.State, acti
 		actionState.AddErrors(errors.Errorf("unexpected response code <%d> when putting app in new space: %s", putApp.ResponseStatusCode, putApp.ResponseBody))
 	}
 	settings.NavigateToSpace(sessionState, actionState, host, destSpace.ID)
+	sessionState.Wait(actionState)
 }
 
 func (settings NavigateToSpaceSettings) NavigateToSpace(sessionState *session.State, actionState *action.State, host string, spaceID string) {
 	if settings.DoNotNavigateToSpace {
 		return
 	}
+	if !settings.KeepCurrent {
+		sessionState.ArtifactMap.ClearArtifactMap()
+	}
 	_, err := sessionState.Rest.GetSync(fmt.Sprintf("%s/api/v1/spaces/%s/assignments?limit=100", host, spaceID), actionState, sessionState.LogEntry, nil)
 	if err != nil {
 		actionState.AddErrors(errors.Wrap(err, "failed during navigate to space"))
 		return
 	}
+	itemsReq, err := sessionState.Rest.GetSync(
+		fmt.Sprintf("%s/api/v1/items?sort=-updatedAt&limit=24&spaceId=%s&resourceType=app,qvapp,qlikview,genericlink,sharingservicetask", host, spaceID),
+		actionState, sessionState.LogEntry, nil,
+	)
+	fillAppMapFromItemRequest(sessionState, actionState, itemsReq, false)
 }
 
 func (settings DestinationSpace) ResolveDestinationSpace(sessionState *session.State, actionState *action.State, host string) (*elasticstructs.Space, error) {

--- a/scenario/elasticmoveapp.go
+++ b/scenario/elasticmoveapp.go
@@ -123,6 +123,10 @@ func (settings NavigateToSpaceSettings) NavigateToSpace(sessionState *session.St
 		fmt.Sprintf("%s/api/v1/items?sort=-updatedAt&limit=24&spaceId=%s&resourceType=app,qvapp,qlikview,genericlink,sharingservicetask", host, spaceID),
 		actionState, sessionState.LogEntry, nil,
 	)
+	if err != nil {
+		actionState.AddErrors(errors.Wrap(err, "failed during navigate to space"))
+		return
+	}
 	fillAppMapFromItemRequest(sessionState, actionState, itemsReq, false)
 }
 


### PR DESCRIPTION
**Checklist**

- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Make elasticmoveapp navigate to space by default

