### PR TITLE
Add support for grid charts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -292,7 +292,8 @@ These are the current limitations in Gopherciser:
 * Map: 
   * Selections can only be made in the first layer (that is, layer 0)
 * Visualization bundle:
-  * Selections are not fully supported in the Heatmap chart
+  * Selections are not fully supported in the Heatmap chart.
+  * Selections not supported in Grid chart.
 * Dashboard bundle:
   * Changing variables using variable input not supported.
   * Selections done by animator not supported.

--- a/enigmahandlers/enigmaobject.go
+++ b/enigmahandlers/enigmaobject.go
@@ -21,11 +21,12 @@ type (
 	}
 
 	objectData struct {
-		properties *enigma.GenericObjectProperties
-		childlist  *enigma.ChildList
-		children   *[]ObjChild
-		listobject *enigma.ListObject
-		hypercube  *HyperCube
+		properties    *enigma.GenericObjectProperties
+		childlist     *enigma.ChildList
+		children      *[]ObjChild
+		listobject    *enigma.ListObject
+		hypercube     *HyperCube
+		treeDataPages []*enigma.NxTreeNode
 	}
 
 	// Object sense object handler
@@ -244,6 +245,19 @@ func (obj *Object) SetPivotHyperCubePages(datapages []*enigma.NxPivotPage) error
 		return errors.Errorf("object<%s> has no hypercube", obj.ID)
 	}
 	obj.data.hypercube.PivotDataPages = datapages
+	return nil
+}
+
+// SetTreeDataPages on object
+func (obj *Object) SetTreeDataPages(treeDataPages []*enigma.NxTreeNode) error {
+	obj.lockData.Lock()
+	defer obj.lockData.Unlock()
+
+	if obj.data == nil {
+		return errors.Errorf("object<%s> has no data structure", obj.ID)
+	}
+
+	obj.data.treeDataPages = treeDataPages
 	return nil
 }
 

--- a/scenario/select.go
+++ b/scenario/select.go
@@ -474,20 +474,14 @@ func getPossible(obj *enigmahandlers.Object, dataDefType senseobjdef.DataDefType
 		}
 
 		switch hypercube.Mode {
-		case constant.HyperCubeDataModePivot:
-			fallthrough
-		case constant.HyperCubeDataModePivotL:
+		case constant.HyperCubeDataModePivot, constant.HyperCubeDataModePivotL:
 			return nil, nil, errors.Errorf("Hypercube Pivot mode not supported")
-		case constant.HyperCubeDataModePivotStack:
-			fallthrough
-		case constant.HyperCubeDataModePivotStackL:
+		case constant.HyperCubeDataModePivotStack, constant.HyperCubeDataModePivotStackL:
 			if selectionType.IsExcludedOrDeselect() {
 				return nil, nil, errors.Errorf("selection type<%s> not supported for stacked/pivot hyper cube", selectionType.String())
 			}
 			possible, err = getPossibleFromStackedHyperCube(obj.ID, hypercube, dim)
-		case constant.HyperCubeDataModeStraight:
-			fallthrough
-		case constant.HyperCubeDataModeStraightL:
+		case constant.HyperCubeDataModeStraight, constant.HyperCubeDataModeStraightL:
 			if hypercube.Binned {
 				if selectionType.IsExcludedOrDeselect() {
 					return nil, nil, errors.Errorf("selection type<%s> not supported for binned hyper cube", selectionType.String())
@@ -497,9 +491,7 @@ func getPossible(obj *enigmahandlers.Object, dataDefType senseobjdef.DataDefType
 			} else {
 				possible, err = getPossibleFromStraightHyperCube(obj.ID, hypercube, dim, columns, selectionType)
 			}
-		case constant.HyperCubeDataModeTree:
-			fallthrough
-		case constant.HyperCubeDataModeTreeL:
+		case constant.HyperCubeDataModeTree, constant.HyperCubeDataModeTreeL:
 			return nil, nil, errors.Errorf("Hypercube tree mode not supported")
 		default:
 			return nil, nil, errors.Errorf("Hypercube mode<%d> not supported", dataDefType)

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -680,8 +680,9 @@ var (
 			{DataCore{
 				Requests: []GetDataRequests{
 					{
-						Type: DataTypeHyperCubeTreeData,
-						Path: "/qHyperCubeDef",
+						Type:   DataTypeHyperCubeTreeData,
+						Path:   "/qHyperCubeDef",
+						Height: 50,
 					},
 				},
 			}},

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -673,7 +673,7 @@ var (
 
 	DefaultSNGridChart = ObjectDef{
 		DataDef: DataDef{
-			Type: DataDefHyperCube, // TODO support tree data
+			Type: DataDefHyperCube,
 			Path: "/qHyperCube",
 		},
 		Data: []Data{

--- a/senseobjdef/defaultdefinitions.go
+++ b/senseobjdef/defaultdefinitions.go
@@ -671,6 +671,24 @@ var (
 		Select: nil,
 	}
 
+	DefaultSNGridChart = ObjectDef{
+		DataDef: DataDef{
+			Type: DataDefHyperCube, // TODO support tree data
+			Path: "/qHyperCube",
+		},
+		Data: []Data{
+			{DataCore{
+				Requests: []GetDataRequests{
+					{
+						Type: DataTypeHyperCubeTreeData,
+						Path: "/qHyperCubeDef",
+					},
+				},
+			}},
+		},
+		Select: nil, // TODO support select in grid chart, select using unsupported SelectPivotCells method
+	}
+
 	DefaultObjectDefs = ObjectDefs{
 		"listbox":               &DefaultListboxDef,
 		"filterpane":            &DefaultFilterpane,
@@ -711,5 +729,6 @@ var (
 		"qlik-animator":         &DefaultQlikAnimator,
 		"qlik-date-picker":      &DefaultQlikDatePicker,
 		"sn-video-player":       &DefaultSNVideoPlayer,
+		"sn-grid-chart":         &DefaultSNGridChart,
 	}
 )

--- a/senseobjdef/senseobjdef.go
+++ b/senseobjdef/senseobjdef.go
@@ -3,13 +3,13 @@ package senseobjdef
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qlik-oss/gopherciser/helpers"
 	"io/ioutil"
 	"os"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 	"github.com/qlik-oss/gopherciser/enummap"
+	"github.com/qlik-oss/gopherciser/helpers"
 )
 
 type (
@@ -125,6 +125,8 @@ const (
 	DataTypeHyperCubeStackData
 	// DataTypeHyperCubeContinuousData get hypercube continuous data
 	DataTypeHyperCubeContinuousData
+	// DataTypeHyperCubeTreeData get hypercube tree data
+	DataTypeHyperCubeTreeData
 )
 
 var (
@@ -153,6 +155,7 @@ var (
 		"hypercubestackdata":      int(DataTypeHyperCubeStackData),
 		"hypercubedatacolumns":    int(DataTypeHyperCubeDataColumns),
 		"hypercubecontinuousdata": int(DataTypeHyperCubeContinuousData),
+		"hypercubetreedata":       int(DataTypeHyperCubeTreeData),
 	})
 
 	jsonit = jsoniter.ConfigCompatibleWithStandardLibrary

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -608,9 +608,13 @@ func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action
 			nodes = append(nodes, node)
 		}
 
-		gob.GetHyperCubeTreeData(ctx, requestDef.Path, &enigma.NxTreeDataOption{
+		// TODO save tree to object hypercube?
+		_, err := gob.GetHyperCubeTreeData(ctx, requestDef.Path, &enigma.NxTreeDataOption{
 			TreeNodes: nodes,
 		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
 
 		return nil
 	}, actionState, true, fmt.Sprintf("failed to get tree data for object<%s>", gob.GenericId))

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -389,7 +389,7 @@ func UpdateObjectHyperCubeReducedDataAsync(sessionState *State, actionState *act
 	}, actionState, true, fmt.Sprintf("Failed to update object hypercube reduced data for object<%s>", gob.GenericId))
 }
 
-// UpdateObjectHyperCubeBinnedDataAsync sed get hypercube binned data request and update saved hypercube
+// UpdateObjectHyperCubeBinnedDataAsync send get hypercube binned data request and update saved hypercube
 func UpdateObjectHyperCubeBinnedDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -590,11 +590,6 @@ func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action
 				height = requestDef.Height
 			}
 
-			allValues := true
-			if i == 0 {
-				allValues = false
-			}
-
 			node := &enigma.NxPageTreeNode{
 				Area: &enigma.Rect{
 					Left:   i,
@@ -602,7 +597,7 @@ func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action
 					Width:  1,
 					Height: height,
 				},
-				AllValues: allValues,
+				AllValues: i != 0,
 			}
 			nodes = append(nodes, node)
 		}

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -566,7 +566,7 @@ func UpdateObjectHyperCubeContinuousDataAsync(sessionState *State, actionState *
 	}, actionState, true, fmt.Sprintf("failed to get continous data for object<%s>", gob.GenericId))
 }
 
-// UpdateObjectHyperCubeTreeDataAsync send get hypercube tree data request and update saved hypercube
+// UpdateObjectHyperCubeTreeDataAsync send get hypercube tree data request and update saved data
 func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -592,7 +592,6 @@ func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action
 
 			allValues := true
 			if i == 0 {
-				// TODO check client what really decides this
 				allValues = false
 			}
 
@@ -608,11 +607,14 @@ func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action
 			nodes = append(nodes, node)
 		}
 
-		// TODO save tree to object hypercube?
-		_, err := gob.GetHyperCubeTreeData(ctx, requestDef.Path, &enigma.NxTreeDataOption{
+		treeNodes, err := gob.GetHyperCubeTreeData(ctx, requestDef.Path, &enigma.NxTreeDataOption{
 			TreeNodes: nodes,
 		})
 		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		if err := obj.SetTreeDataPages(treeNodes); err != nil {
 			return errors.WithStack(err)
 		}
 

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -282,6 +282,7 @@ func GetObjectProperties(sessionState *State, actionState *action.State, obj *en
 	return sessionState.SendRequest(actionState, getProperties)
 }
 
+// UpdateObjectHyperCubeDataAsync send get straight hypercube data and update saved hypercube
 func UpdateObjectHyperCubeDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests, columns bool) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -340,6 +341,7 @@ func UpdateObjectHyperCubeDataAsync(sessionState *State, actionState *action.Sta
 	}, actionState, true, fmt.Sprintf("Failed to update object hypercube data for object<%s>", gob.GenericId))
 }
 
+// UpdateObjectHyperCubeReducedDataAsync send get hypercube reduced data request and update saved hypercube
 func UpdateObjectHyperCubeReducedDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -387,6 +389,7 @@ func UpdateObjectHyperCubeReducedDataAsync(sessionState *State, actionState *act
 	}, actionState, true, fmt.Sprintf("Failed to update object hypercube reduced data for object<%s>", gob.GenericId))
 }
 
+// UpdateObjectHyperCubeBinnedDataAsync sed get hypercube binned data request and update saved hypercube
 func UpdateObjectHyperCubeBinnedDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -465,6 +468,7 @@ func UpdateObjectHyperCubeBinnedDataAsync(sessionState *State, actionState *acti
 	}, actionState, true, fmt.Sprintf("Failed to update object binned data for object<%s>", gob.GenericId))
 }
 
+// UpdateObjectHyperCubeStackDataAsync send get stacked hypercube data and update saved hypercube
 func UpdateObjectHyperCubeStackDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -507,6 +511,7 @@ func UpdateObjectHyperCubeStackDataAsync(sessionState *State, actionState *actio
 	}, actionState, true, fmt.Sprintf("Failed to update object stack data for object<%s>", gob.GenericId))
 }
 
+// UpdateListObjectDataAsync send get listobject data and update saved list object
 func UpdateListObjectDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -529,9 +534,10 @@ func UpdateListObjectDataAsync(sessionState *State, actionState *action.State, g
 		}
 
 		return nil
-	}, actionState, true, fmt.Sprintf("Failed to get listobject data for object<%s>", gob.GenericId))
+	}, actionState, true, fmt.Sprintf("failed to get listobject data for object<%s>", gob.GenericId))
 }
 
+// UpdateObjectHyperCubeContinuousDataAsync send get continous data request
 func UpdateObjectHyperCubeContinuousDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
 	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
 	sessionState.QueueRequest(func(ctx context.Context) error {
@@ -544,7 +550,7 @@ func UpdateObjectHyperCubeContinuousDataAsync(sessionState *State, actionState *
 		start, end, err := GetFullContinuousRange(hypercube)
 		sessionState.LogEntry.LogDebugf("Get continuous data for object with start <%v> and end <%v>", start, end)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get continuous data for object<%s>", obj.ID)
+			return errors.WithStack(err)
 		}
 		_, _, err = gob.GetHyperCubeContinuousData(ctx, requestDef.Path, &enigma.NxContinuousDataOptions{
 			Start:          start,
@@ -554,10 +560,60 @@ func UpdateObjectHyperCubeContinuousDataAsync(sessionState *State, actionState *
 			MaxNumberLines: &maxLines,
 		}, false)
 		if err != nil {
-			return errors.Wrapf(err, "failed to get continuous data for object<%s>", obj.ID)
+			return errors.WithStack(err)
 		}
 		return nil
-	}, actionState, true, fmt.Sprintf("Failed to get continous data for object<%s>", gob.GenericId))
+	}, actionState, true, fmt.Sprintf("failed to get continous data for object<%s>", gob.GenericId))
+}
+
+// UpdateObjectHyperCubeTreeDataAsync send get hypercube tree data request and update saved hypercube
+func UpdateObjectHyperCubeTreeDataAsync(sessionState *State, actionState *action.State, gob *enigma.GenericObject,
+	obj *enigmahandlers.Object, requestDef senseobjdef.GetDataRequests) {
+	sessionState.QueueRequest(func(ctx context.Context) error {
+		sessionState.LogEntry.LogDebugf("Get tree data for object<%s> type<%s>", gob.GenericId, gob.GenericType)
+
+		hypercube := obj.HyperCube()
+		if hypercube == nil {
+			return errors.Errorf("no hybercube found for object<%s> type<%s>", gob.GenericId, gob.GenericType)
+		}
+
+		dimInfo := hypercube.DimensionInfo
+		if len(dimInfo) < 1 {
+			return errors.Errorf("no dimensions found for object<%s> type<%s>", gob.GenericId, gob.GenericType)
+		}
+
+		nodes := make([]*enigma.NxPageTreeNode, 0, len(dimInfo))
+
+		for i, dim := range dimInfo {
+			height := dim.Cardinal
+			if height > requestDef.Height {
+				height = requestDef.Height
+			}
+
+			allValues := true
+			if i == 0 {
+				// TODO check client what really decides this
+				allValues = false
+			}
+
+			node := &enigma.NxPageTreeNode{
+				Area: &enigma.Rect{
+					Left:   i,
+					Top:    0,
+					Width:  1,
+					Height: height,
+				},
+				AllValues: allValues,
+			}
+			nodes = append(nodes, node)
+		}
+
+		gob.GetHyperCubeTreeData(ctx, requestDef.Path, &enigma.NxTreeDataOption{
+			TreeNodes: nodes,
+		})
+
+		return nil
+	}, actionState, true, fmt.Sprintf("failed to get tree data for object<%s>", gob.GenericId))
 }
 
 func checkHyperCubeErr(id string, err *enigma.NxValidationError) error {
@@ -700,7 +756,7 @@ func SetObjectData(sessionState *State, actionState *action.State, rawLayout jso
 		case senseobjdef.DataTypeHyperCubeContinuousData:
 			UpdateObjectHyperCubeContinuousDataAsync(sessionState, actionState, enigmaObject, obj, r)
 		case senseobjdef.DataTypeHyperCubeTreeData:
-			return errors.New("DataTypeHyperCubeTreeData not yet implemented")
+			UpdateObjectHyperCubeTreeDataAsync(sessionState, actionState, enigmaObject, obj, r)
 		default:
 			sessionState.LogEntry.Logf(logger.WarningLevel,
 				"Get Data for object type<%s> not supported", enigmaObject.GenericType)

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -699,6 +699,8 @@ func SetObjectData(sessionState *State, actionState *action.State, rawLayout jso
 			UpdateObjectHyperCubeStackDataAsync(sessionState, actionState, enigmaObject, obj, r)
 		case senseobjdef.DataTypeHyperCubeContinuousData:
 			UpdateObjectHyperCubeContinuousDataAsync(sessionState, actionState, enigmaObject, obj, r)
+		case senseobjdef.DataTypeHyperCubeTreeData:
+			return errors.New("DataTypeHyperCubeTreeData not yet implemented")
 		default:
 			sessionState.LogEntry.Logf(logger.WarningLevel,
 				"Get Data for object type<%s> not supported", enigmaObject.GenericType)


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated


**Squash commit message**

Add support for getting data for `sn-grid-chart`.

**Info**

Saving tree data pages has been added in this PR, however two steps still left to be able to support `select` in grid chart

* Add support for hypercube tree mode in `getpossible` part of select function.
* Add support for sending `SelectPivotCells` select request using the saved tree data pages.

The `allvalues` part of getting data might need re-evaluation in case we add more objects based on tree data in the future. Current will send correct requests for grid charts.
