### PR TITLE
only do random selection in object with at least one dimension

### DIFF
--- a/scenario/randomaction.go
+++ b/scenario/randomaction.go
@@ -306,7 +306,8 @@ func getSelectableObjectsOnSheet(sessionState *session.State) ([]*enigmahandlers
 		if err != nil {
 			continue
 		}
-		if objectDef.Select != nil && objectDef.Select.Type != senseobjdef.SelectTypeUnknown {
+		if objectDef.Select != nil && objectDef.Select.Type != senseobjdef.SelectTypeUnknown && // has select definition
+			obj.HyperCube() != nil && len(obj.HyperCube().DimensionInfo) > 0 { // has at least one dimension
 			selectableObjects = append(selectableObjects, obj)
 		}
 	}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

* Don't include objects without dimensions for random selections using randomaction, e.g. tables with only measures.

**Info**

Before:
```bash
2021-03-04T10:20:35+01:00 Err<0> Warn<0> ActvSess<0> TotSess<0> Actns<0> Reqs<0>
TotErrors<2> TotWarnings<0> TotActions<7> TotRequests<40> Duration<2.634072s>
1 error occurred:
Failed to get cardinal for object<ZmqVAW>: object<ZmqVAW> does not contain a dimensionlist
```

Now:
```bash
2021-03-04T10:21:04+01:00 Err<0> Warn<0> ActvSess<0> TotSess<0> Actns<0> Reqs<0>
TotErrors<0> TotWarnings<0> TotActions<8> TotRequests<49> Duration<2.8247619s>
```