### PR TITLE
Enhancement/755 event wait timeouts

### DIFF
--- a/scenario/elasticcreateapp.go
+++ b/scenario/elasticcreateapp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/elasticstructs"
 	"github.com/qlik-oss/gopherciser/eventws"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"github.com/qlik-oss/gopherciser/session"
 )
 
@@ -159,7 +160,7 @@ func (settings ElasticCreateAppSettings) Execute(sessionState *session.State, ac
 				return e.Operation == eventws.OperationCreated && e.ResourceID == appItemID
 			},
 		)
-		if err != nil {
+		if err != nil && !helpers.IsContextTriggered(sessionState.BaseContext()) {
 			actionState.AddErrors(errors.Wrapf(err,
 				"did not recieve created and updated items events for app<%s> with item id<%s>",
 				appName, appItemID,

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -164,10 +164,11 @@ func (settings ElasticReloadSettings) execute(sessionState *session.State, actio
 		return
 	}
 
-	timeoutChan := make(<-chan time.Time) // Dummy channel in case no timeout defined
-	if settings.Timeout > 0 {
-		timeoutChan = time.After(time.Duration(settings.Timeout))
+	timeout := time.Duration(settings.Timeout)
+	if timeout < time.Second {
+		timeout = time.Hour
 	}
+	timeoutChan := time.After(timeout)
 
 	reloadID := postReloadResponse.ID
 forLoop:

--- a/scenario/elasticreload.go
+++ b/scenario/elasticreload.go
@@ -174,6 +174,17 @@ forLoop:
 	for {
 		select {
 		case <-timeoutChan:
+			ongoing, err := checkStatusOngoing(sessionState, actionState, host, reloadID)
+			if err != nil {
+				actionState.AddErrors(errors.New("timeout waiting on reload result event and failed to get ongoing status"))
+				return
+			}
+
+			if !ongoing {
+				actionState.AddErrors(errors.New("timeout waiting on reload result event, but reload no longer ongoing"))
+				return
+			}
+
 			actionState.AddErrors(errors.New("timeout waiting on reload result event"))
 			return
 		case <-sessionState.BaseContext().Done():


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

* Add possible timeout option to elasticreload action
* Don't log errors in elasticcreate app if base context is triggered

**Info**

Should we default to a large timeout instead of no timeout? E.g. maybe 1 hour?
