### PR TITLE
Add `unique` parameter to `openapp` for forcing unique engine session.

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -120,16 +120,16 @@ func (connectionSettings *ConnectionSettings) Validate() error {
 }
 
 // GetConnectFunc Get function for connecting to sense
-func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID string) (func() (string, error), error) {
+func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID string, customHeaders http.Header) (func() (string, error), error) {
 	header, err := connectionSettings.GetHeaders(state)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 	switch connectionSettings.Mode {
 	case JWT:
-		return connectionSettings.JwtSettings.GetConnectFunc(state, connectionSettings, appGUID, header), nil
+		return connectionSettings.JwtSettings.GetConnectFunc(state, connectionSettings, appGUID, header, customHeaders), nil
 	case WS:
-		return connectionSettings.WsSettings.GetConnectFunc(state, connectionSettings, appGUID, header), nil
+		return connectionSettings.WsSettings.GetConnectFunc(state, connectionSettings, appGUID, header, customHeaders), nil
 	default:
 		return nil, errors.Errorf("Unknown connection mode <%d>", connectionSettings.Mode)
 	}

--- a/connection/jwtconnection.go
+++ b/connection/jwtconnection.go
@@ -51,7 +51,7 @@ type (
 )
 
 // GetConnectFunc which establishes a connection to Qlik Sense
-func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID string, headers http.Header) func() (string, error) {
+func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID string, headers, customHeaders http.Header) func() (string, error) {
 	connectFunc := func() (string, error) {
 		url, err := connection.GetURL(appGUID)
 
@@ -80,7 +80,16 @@ func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State
 				return appGUID, errors.Wrap(err, "failed creating cookie jar")
 			}
 		}
-		if err = sense.Connect(ctx, url, headers, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout); err != nil {
+
+		// combine headers for connection
+		connectHeaders := make(http.Header)
+		for k, v := range headers {
+			connectHeaders[k] = v
+		}
+		for k, v := range customHeaders {
+			connectHeaders[k] = v
+		}
+		if err = sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout); err != nil {
 			return appGUID, errors.WithStack(err)
 		}
 

--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -15,7 +15,7 @@ type (
 )
 
 // GetConnectFunc get ws connect function
-func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID string, header http.Header) func() (string, error) {
+func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID string, headers, customHeaders http.Header) func() (string, error) {
 	return func() (string, error) {
 		if sessionState == nil {
 			return appGUID, errors.New("Session state is nil")
@@ -47,7 +47,16 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 		ctx, cancel := sessionState.ContextWithTimeout(sessionState.BaseContext())
 		defer cancel()
 
-		if err := sense.Connect(ctx, url, header, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
+		// combine headers for connection
+		connectHeaders := make(http.Header)
+		for k, v := range headers {
+			connectHeaders[k] = v
+		}
+		for k, v := range customHeaders {
+			connectHeaders[k] = v
+		}
+
+		if err := sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
 			return appGUID, errors.Wrap(err, "Failed connecting to sense server")
 		}
 

--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -718,6 +718,7 @@ Open an app.
 * `app`: App name or app GUID (supports the use of [session variables](#session_variables)). Used with `appmode` set to `guid` or `name`.
 * `list`: List of apps. Used with `appmode` set to `randomnamefromlist`, `randomguidfromlist`, `roundnamefromlist` or `roundguidfromlist`.
 * `filename`: Path to a file in which each line represents an app. Used with `appmode` set to `randomnamefromfile`, `randomguidfromfile`, `roundnamefromfile` or `roundguidfromfile`.
+* `unique`: Create unqiue engine session not re-using session from previous connection with same user. Defaults to false.
 
 ### Examples
 

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -451,6 +451,9 @@
     "listboxselect.accept": [
         "Accept or abort selection after selection (only used with `wrap`) (`true` / `false`)."
     ],
+    "openapp.unique" : [
+        "Create unqiue engine session not re-using session from previous connection with same user. Defaults to false."
+    ],
     "productversion.log": [
         "Save the product version to the log (`true` / `false`). Defaults to `false`, if omitted."
     ],

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -338,6 +338,7 @@ var (
 		"listboxselect.id":                                {"ID of the listbox in which to select values."},
 		"listboxselect.type":                              {"Selection type.", "`all`: Select all values.", "`alternative`: Select alternative values.", "`excluded`: Select excluded values.", "`possible`: Select possible values."},
 		"listboxselect.wrap":                              {"Wrap selection with Begin / End selection requests (`true` / `false`)."},
+		"openapp.unique":                                  {"Create unqiue engine session not re-using session from previous connection with same user. Defaults to false."},
 		"productversion.log":                              {"Save the product version to the log (`true` / `false`). Defaults to `false`, if omitted."},
 		"publishsheet.mode":                               {"", "`allsheets`: Publish all sheets in the app.", "`sheetids`: Only publish the sheets specified by the `sheetIds` array."},
 		"publishsheet.sheetIds":                           {"(optional) Array of sheet IDs for the `sheetids` mode."},

--- a/scenario/connfunchandler.go
+++ b/scenario/connfunchandler.go
@@ -42,7 +42,7 @@ func GetConnTestFuncs() []func(*connection.ConnectionSettings, *session.State, *
 }
 
 func defaultGuidWsConnectTest(connectionSettings *connection.ConnectionSettings, sessionState *session.State, actionState *action.State) error {
-	connectFunc, err := connectionSettings.GetConnectFunc(sessionState, "00000000-0000-0000-0000-000000000000")
+	connectFunc, err := connectionSettings.GetConnectFunc(sessionState, "00000000-0000-0000-0000-000000000000", nil)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get connect function")
 	}

--- a/scenario/openhub.go
+++ b/scenario/openhub.go
@@ -25,7 +25,7 @@ func (openHub OpenHubSettings) Validate() error {
 func (openHub OpenHubSettings) Execute(sessionState *session.State, actionState *action.State, connectionSettings *connection.ConnectionSettings, label string, setHubStart func()) {
 	actionState.Details = "SenseEfW"
 
-	connectFunc, err := connectionSettings.GetConnectFunc(sessionState, "")
+	connectFunc, err := connectionSettings.GetConnectFunc(sessionState, "", nil)
 	if err != nil {
 		actionState.AddErrors(errors.Wrapf(err, "failed to get connect function"))
 		return


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated


**Squash commit message**

Add `unique` parameter to `openapp` for forcing unique engine session not re-using previous session state for user.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
