### PR TITLE
correct value for WS Response stall logging

### DIFF
--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -363,7 +363,7 @@ func (uplink *SenseUplink) LogMetric(invocation *enigma.Invocation, metrics *eni
 
 	respStall := metrics.InvocationResponseTimestamp.Sub(metrics.SocketReadTimestamp)
 	if !metrics.InvocationRequestTimestamp.IsZero() && !metrics.SocketReadTimestamp.IsZero() && respStall > constant.MaxStallTime {
-		uplink.logEntry.LogDetail(logger.WarningLevel, "WS response stall", strconv.FormatInt(reqStall.Nanoseconds(), 10))
+		uplink.logEntry.LogDetail(logger.WarningLevel, "WS response stall", strconv.FormatInt(respStall.Nanoseconds(), 10))
 	}
 
 }

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -57,7 +57,7 @@ case $LINTLEVEL in
 # subrules currently disabled:
 #   * structtag : We override tags in engima, so structtag complains about repeating tags, found no way to tell it this is intended.
 MIN)
-  "$GOPATH"/bin/golangci-lint run -D structcheck
+  "$GOPATH"/bin/golangci-lint run -D structcheck --timeout 5m
   ;;
 # Default set of linters
 *)


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Correct stall value for "WS response stall" logging

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
