### PR TITLE
Enhancement/900 breakonerrorcount

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -228,13 +228,8 @@ func execute() error {
 	}
 
 	// === Handle SIGINT ===
-	ctx, cancel := context.WithCancel(context.Background())
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c
-		cancel()
-	}()
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
 
 	// === Prometheus section ===
 	if metricsPort > 0 {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -255,6 +255,12 @@ func execute() error {
 	}{strings.Split(filepath.Base(cfgFile), ".")[0]}
 
 	// === start execution ===
+	cfg.Scheduler.SetCancel(func(msg string) {
+		if msg != "" {
+			os.Stderr.WriteString(fmt.Sprintf("%s\n", msg))
+		}
+		cancel()
+	})
 	return cfg.Execute(ctx, templateData)
 }
 

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -228,8 +228,17 @@ func execute() error {
 	}
 
 	// === Handle SIGINT ===
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	// this could be replaced by
+	// 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	// when moving above go 1.15
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		cancel()
+	}()
 
 	// === Prometheus section ===
 	if metricsPort > 0 {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -127,7 +127,7 @@ var executeCmd = &cobra.Command{
 		}()
 
 		if execErr := execute(); execErr != nil {
-			errMsg := "Unknown error"
+			var errMsg string
 			var exitCode int
 
 			cause := errors.Cause(execErr)

--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -2214,6 +2214,7 @@ This section of the JSON file contains scheduler settings for the users in the l
       * `1.0`: If the previous attempt to re-connect failed, wait 1.0s before attempting again
       * `10.0`: If the previous attempt to re-connect failed, wait 10.0s before attempting again
       * `20.0`: If the previous attempt to re-connect failed, wait 20.0s before attempting again
+* `maxerrors`: Break execution if max errors exceeded. 0 - Do not break. Defaults to 0.
 * `settings`: 
   * `executionTime`: Test execution time (seconds). The sessions are disconnected when the specified time has elapsed. Allowed values are positive integers. `-1` means an infinite execution time.
   * `iterations`: Number of iterations for each 'concurrent' user to repeat. Allowed values are positive integers. `-1` means an infinite number of iterations.

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -224,6 +224,9 @@
     "config.scheduler.instance": [
         "Instance number for this instance. Use different instance numbers when running the same script in multiple instances to make sure the randomization is different in each instance. Defaults to 1."
     ],
+    "config.scheduler.maxerrors": [
+        "Break execution if max errors exceeded. 0 - Do not break. Defaults to 0."
+    ],
     "config.settings": [
         "This section of the JSON file contains timeout and logging settings for the load scenario"
     ],

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -211,6 +211,7 @@ var (
 		"config.scheduler.iterationtimebuffer":            {""},
 		"config.scheduler.iterationtimebuffer.duration":   {"Duration of the time buffer (for example, `500ms`, `30s` or `1m10s`). Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`."},
 		"config.scheduler.iterationtimebuffer.mode":       {"Time buffer mode. Defaults to `nowait`, if omitted.", "`nowait`: No time buffer in between the iterations.", "`constant`: Add a constant time buffer after each iteration. Defined by `duration`.", "`onerror`: Add a time buffer in case of an error. Defined by `duration`.", "`minduration`: Add a time buffer if the iteration duration is less than `duration`."},
+		"config.scheduler.maxerrors":                      {"Break execution if max errors exceeded. 0 - Do not break. Defaults to 0."},
 		"config.scheduler.reconnectsettings":              {"Settings for enabling re-connection attempts in case of unexpected disconnects."},
 		"config.scheduler.settings":                       {""},
 		"config.scheduler.settings.concurrentusers":       {"Number of concurrent users to simulate. Allowed values are positive integers."},

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -231,7 +231,7 @@ func (sched *Scheduler) startNewUser(ctx context.Context, timeout time.Duration,
 		err := sched.runIteration(userScenario, sessionState, ctx)
 		if err != nil {
 			mErr = multierror.Append(mErr, err)
-			if sched.MaxErrorCount > 0 && counters.Errors.Current() > sched.MaxErrorCount {
+			if !helpers.IsContextTriggered(ctx) && sched.MaxErrorCount > 0 && counters.Errors.Current() > sched.MaxErrorCount {
 				globalLogEntry := log.NewLogEntry()
 				msg := fmt.Sprintf("Max error count of %d surpassed, aborting execution!", sched.MaxErrorCount)
 				globalLogEntry.Log(logger.ErrorLevel, msg)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -231,7 +231,7 @@ func (sched *Scheduler) startNewUser(ctx context.Context, timeout time.Duration,
 		err := sched.runIteration(userScenario, sessionState, ctx)
 		if err != nil {
 			mErr = multierror.Append(mErr, err)
-			if counters.Errors.Current() > sched.MaxErrorCount {
+			if sched.MaxErrorCount > 0 && counters.Errors.Current() > sched.MaxErrorCount {
 				globalLogEntry := log.NewLogEntry()
 				msg := fmt.Sprintf("Max error count of %d surpassed, aborting execution!", sched.MaxErrorCount)
 				globalLogEntry.Log(logger.ErrorLevel, msg)
@@ -308,7 +308,9 @@ func (sched *Scheduler) Cancel(msg string) {
 	if sched == nil {
 		return
 	}
-	sched.cancel(msg)
+	if sched.cancel != nil {
+		sched.cancel(msg)
+	}
 }
 
 func logErrReport(sessionState *session.State) {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -39,6 +39,9 @@ type (
 		RequireScenario() bool
 		// PopulateHookData populate map with data which can be used by go template in hooks
 		PopulateHookData(data map[string]interface{})
+
+		Cancel(msg string)
+		SetCancel(cancel func(msg string))
 	}
 
 	// Scheduler common core of schedulers
@@ -51,10 +54,14 @@ type (
 		InstanceNumber uint64 `json:"instance" doc-key:"config.scheduler.instance"`
 		// ReconnectSettings settings for re-connecting websocket on unexpected disconnect
 		ReconnectSettings session.ReconnectSettings `json:"reconnectsettings" doc-key:"config.scheduler.reconnectsettings"`
+		// MaxErrorCount abort scheduler after error count is reached
+		MaxErrorCount uint64 `json:"maxerrors,omitempty" doc-key:"config.scheduler.maxerrors"`
 
 		connectionSettings *connection.ConnectionSettings
 
 		continueOnErrors bool
+
+		cancel func(msg string)
 	}
 
 	schedulerTmp struct {
@@ -224,6 +231,14 @@ func (sched *Scheduler) startNewUser(ctx context.Context, timeout time.Duration,
 		err := sched.runIteration(userScenario, sessionState, ctx)
 		if err != nil {
 			mErr = multierror.Append(mErr, err)
+			if counters.Errors.Current() > sched.MaxErrorCount {
+				globalLogEntry := log.NewLogEntry()
+				msg := fmt.Sprintf("Max error count of %d surpassed, aborting execution!", sched.MaxErrorCount)
+				globalLogEntry.Log(logger.ErrorLevel, msg)
+
+				sched.Cancel(msg)
+				break
+			}
 		}
 
 		if err := sched.TimeBuf.Wait(ctx, false); err != nil {
@@ -278,6 +293,22 @@ func (sched *Scheduler) runIteration(userScenario []scenario.Action, sessionStat
 		}
 	}
 	return nil
+}
+
+// SetCancel function to execute to cancel all executions
+func (sched *Scheduler) SetCancel(cancel func(msg string)) {
+	if sched == nil {
+		return
+	}
+	sched.cancel = cancel
+}
+
+// Cancel all executions
+func (sched *Scheduler) Cancel(msg string) {
+	if sched == nil {
+		return
+	}
+	sched.cancel(msg)
 }
 
 func logErrReport(sessionState *session.State) {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated


**Squash commit message**

Add `maxerrors` setting on scheduler level of config. If set, have execution break if error count > then set limit.

**Info**

example of stdout message + entry in logfile

```bash
λ ~/dev/qlik-oss/gopherciser/ enhancement/900-breakonerrorcount ./build/gopherciser x -c ./localtests/QlikCoreWithError.json
2021-09-09T13:07:58+02:00 Err<0> Warn<0> ActvSess<0> TotSess<0> Actns<0> Reqs<0>
Max error count of 1 surpassed, aborting execution!
TotErrors<2> TotWarnings<4> TotActions<60> TotRequests<1454> Duration<2.4032044s>
2 errors occurred:
First error: failed to get sheet: failed to get properties for sheet<doesnotexist>: Invalid handle: Invalid Params (-32602 JSON RPC INVALID PARAMETERS)
λ ~/dev/qlik-oss/gopherciser/ enhancement/900-breakonerrorcount grep error logs/$(ls -t logs| head -n 1) | cut -c -120
2021-09-09T13:07:58.7620076+02:00                       0       info    Script  {"scenario":[{"action":"openapp","label":"Open qlik core","disabled":f
2021-09-09T13:08:00.1090483+02:00       changesheet             30      error           failed to get sheet: failed to get properties for sheet<doesnot
2021-09-09T13:08:01.1650114+02:00       changesheet             60      error           failed to get sheet: failed to get properties for sheet<doesnot
2021-09-09T13:08:01.1651369+02:00                       0       error           Max error count of 1 surpassed, aborting execution!                     0                  00               79              0       0               0
```