### PR TITLE
latest pandoc broken, lock to older 2.15 version

### DIFF
--- a/scripts/docbuild.sh
+++ b/scripts/docbuild.sh
@@ -4,7 +4,10 @@ set -eox pipefail
 BIN=${1:-build}
 USER=$(id -u)
 PROJECTFOLDER=${2:-.}
+PANDOCVERSION=pandoc/core:2.15
+
 echo PROJECTFOLDER:"$PROJECTFOLDER"
+echo PANDOCVERSION:"$PANDOCVERSION"
 
 # Test project folder and change to project folder
 if [[ ! -e $PROJECTFOLDER/docs ]]; then echo "$PROJECTFOLDER"/docs not found; exit 1; fi
@@ -19,7 +22,7 @@ if [[ -x $(command -v docker) ]]; then
     GOPHERCISERDATAVOLUME=$(docker create -v /data alpine:latest /bin/true)
 
     echo creating pandoc container...
-    PANDOCCONTAINER=$(docker create --volumes-from "$GOPHERCISERDATAVOLUME" -it --entrypoint /bin/ash pandoc/core:latest)
+    PANDOCCONTAINER=$(docker create --volumes-from "$GOPHERCISERDATAVOLUME" -it --entrypoint /bin/ash "$PANDOCVERSION")
     docker start "$PANDOCCONTAINER"
 
     # Create folder structure needed


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Latest pandoc version cannot generate docs correctly, lock to version 2.15

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
