### PR TITLE
Better support calculation conditions in some charts

### DIFF
--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -303,10 +303,7 @@ func UpdateObjectHyperCubeDataAsync(sessionState *State, actionState *action.Sta
 			switch err.(type) {
 			case CalcEvalConditionFailedError:
 				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
-				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
-					return errors.Wrap(err, "failed to set hypercube datapages")
-				}
-				return nil
+				return errors.Wrap(obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false), "failed to set hypercube datapages")
 			}
 			return errors.WithStack(err)
 		}
@@ -370,10 +367,7 @@ func UpdateObjectHyperCubeReducedDataAsync(sessionState *State, actionState *act
 			switch err.(type) {
 			case CalcEvalConditionFailedError:
 				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
-				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
-					return errors.Wrap(err, "failed to set hypercube datapages")
-				}
-				return nil
+				return errors.Wrap(obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false), "failed to set hypercube datapages")
 			}
 			return errors.WithStack(err)
 		}
@@ -426,10 +420,7 @@ func UpdateObjectHyperCubeBinnedDataAsync(sessionState *State, actionState *acti
 			switch err.(type) {
 			case CalcEvalConditionFailedError:
 				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
-				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
-					return errors.Wrap(err, "failed to set hypercube datapages")
-				}
-				return nil
+				return errors.Wrap(obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false), "failed to set hypercube datapages")
 			}
 			return errors.WithStack(err)
 		} else if hypercube.Error != nil {
@@ -515,10 +506,7 @@ func UpdateObjectHyperCubeStackDataAsync(sessionState *State, actionState *actio
 			switch err.(type) {
 			case CalcEvalConditionFailedError:
 				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
-				if err = obj.SetStackHyperCubePages(make([]*enigma.NxStackPage, 0)); err != nil {
-					return errors.Wrap(err, "failed to set hypercube datapages")
-				}
-				return nil
+				return errors.Wrap(obj.SetStackHyperCubePages(make([]*enigma.NxStackPage, 0)), "failed to set hypercube datapages")
 			}
 			return errors.WithStack(err)
 		}

--- a/session/objecthandling.go
+++ b/session/objecthandling.go
@@ -26,6 +26,8 @@ type (
 		m         map[string]ObjectHandler
 		writeLock sync.Mutex
 	}
+
+	CalcEvalConditionFailedError struct{}
 )
 
 const (
@@ -45,6 +47,11 @@ func init() {
 	if err := GlobalObjectHandler.RegisterHandler("container", &ContainerHandler{}, false); err != nil {
 		panic(err)
 	}
+}
+
+// Error implements error interface
+func (err CalcEvalConditionFailedError) Error() string {
+	return "object has unsatisfied calculation condition"
 }
 
 // RegisterHandler for object type, override existing handler with override flag
@@ -292,12 +299,20 @@ func UpdateObjectHyperCubeDataAsync(sessionState *State, actionState *action.Sta
 			return errors.Errorf("object<%s> has no hypercube", gob.GenericId)
 		}
 
-		if hypercube.Size == nil {
-			return errors.Errorf("object<%s> has no hypercube size", gob.GenericId)
+		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
+			switch err.(type) {
+			case CalcEvalConditionFailedError:
+				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
+				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
+					return errors.Wrap(err, "failed to set hypercube datapages")
+				}
+				return nil
+			}
+			return errors.WithStack(err)
 		}
 
-		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
-			return errors.WithStack(err)
+		if hypercube.Size == nil {
+			return errors.Errorf("object<%s> has no hypercube size", gob.GenericId)
 		}
 
 		if hypercube.Size.Cx < 1 {
@@ -352,6 +367,14 @@ func UpdateObjectHyperCubeReducedDataAsync(sessionState *State, actionState *act
 		}
 
 		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
+			switch err.(type) {
+			case CalcEvalConditionFailedError:
+				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
+				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
+					return errors.Wrap(err, "failed to set hypercube datapages")
+				}
+				return nil
+			}
 			return errors.WithStack(err)
 		}
 
@@ -400,7 +423,17 @@ func UpdateObjectHyperCubeBinnedDataAsync(sessionState *State, actionState *acti
 		}
 
 		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
+			switch err.(type) {
+			case CalcEvalConditionFailedError:
+				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
+				if err = obj.SetHyperCubeDataPages(make([]*enigma.NxDataPage, 0), false); err != nil {
+					return errors.Wrap(err, "failed to set hypercube datapages")
+				}
+				return nil
+			}
 			return errors.WithStack(err)
+		} else if hypercube.Error != nil {
+			return nil
 		}
 
 		if hypercube.Size == nil {
@@ -479,6 +512,14 @@ func UpdateObjectHyperCubeStackDataAsync(sessionState *State, actionState *actio
 		}
 
 		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
+			switch err.(type) {
+			case CalcEvalConditionFailedError:
+				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
+				if err = obj.SetStackHyperCubePages(make([]*enigma.NxStackPage, 0)); err != nil {
+					return errors.Wrap(err, "failed to set hypercube datapages")
+				}
+				return nil
+			}
 			return errors.WithStack(err)
 		}
 
@@ -544,6 +585,11 @@ func UpdateObjectHyperCubeContinuousDataAsync(sessionState *State, actionState *
 		sessionState.LogEntry.LogDebugf("Get continuous data for object<%s>", gob.GenericId)
 		hypercube := obj.HyperCube()
 		if err := checkHyperCubeErr(gob.GenericId, hypercube.Error); err != nil {
+			switch err.(type) {
+			case CalcEvalConditionFailedError:
+				sessionState.LogEntry.Logf(logger.WarningLevel, "object<%s>: %v", obj.ID, err)
+				return nil
+			}
 			return errors.WithStack(err)
 		}
 		maxLines := maxNbrLines
@@ -623,7 +669,7 @@ func checkHyperCubeErr(id string, err *enigma.NxValidationError) error {
 	}
 	switch err.ErrorCode {
 	case constant.LocerrCalcEvalConditionFailed:
-		return nil
+		return CalcEvalConditionFailedError{}
 	default:
 		return errors.Errorf("object<%s> has hypercube error<ErrorCode:%d (%s)>", id, err.ErrorCode, enigma.ErrorCodeLookup(err.ErrorCode))
 	}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Better support calculation conditions for charts with separate data requests.

**Info**

```bash
λ ~/dev/qlik-oss/gopherciser/ bugfix/954-CalcCondition* make quickbuild &&  ./build/gopherciser_osx x -c ./localtests/rd-ajh-openreloadanalyzer.json
GO111MODULE=on go build -mod=readonly -o  ./build/gopherciser_osx
2021-11-22T16:33:53+01:00 Err<0> Warn<0> ActvSess<0> TotSess<0> Actns<0> Reqs<0>
TotErrors<0> TotWarnings<1> TotActions<4> TotRequests<103> Duration<2.373589499s> 
λ ~/dev/qlik-oss/gopherciser/ bugfix/954-CalcCondition* grep -E "\twarning\t" ./logs/$(ls -t ./logs | head -n 1)                                    
2021-11-22T16:33:55.742584+01:00        changesheet             4       warning         object<BSpwem>: object has unsatisfied calculation condition                    0       Reload Analyzer v1.2.1-3        d19b9b59-983d-4723-9422-fe329c0108d7    dlotesters_111               11              0       0               0       0       0       2021-11-22T15:33:55.742584Z
```
