### PR TITLE
custom command no long allowed, using new postUpdateOptions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
 	"enabled": true,
-	"postUpgradeTasks": {
-		"commands": ["go mod tidy", "go mod verify"],
-		"fileFilters": ["go.mod", "go.sum"]
-	}
+	"postUpdateOptions": [
+		"gomodUpdateImportPaths"
+	]
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Our postupgrade commands no longer allowed. Using new options for go, will run go mod tidy and automatically update import paths on mayor upgrades, but will not run `go mod verify` (which will likely cause tests to fail, but see no better options to use).

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
