### PR TITLE
Use default thinktime if default thinktime settings or nil

### DIFF
--- a/scenario/askhubadvisor.go
+++ b/scenario/askhubadvisor.go
@@ -235,6 +235,10 @@ func (settings *AskHubAdvisorSettings) UnmarshalJSON(bytes []byte) error {
 	if err != nil {
 		return err
 	}
+	err = setThinkTimeIfNotSet(&settings.AskHubAdvisorSettingsCore.ThinkTimeSettings, &askHubAdvisorDefaultThinktimeSettings)
+	if err != nil {
+		return err
+	}
 	switch settings.QuerySource {
 	case QueryFromFile:
 		if settings.FileName == "" {

--- a/scenario/askhubadvisor.go
+++ b/scenario/askhubadvisor.go
@@ -235,10 +235,10 @@ func (settings *AskHubAdvisorSettings) UnmarshalJSON(bytes []byte) error {
 	if err != nil {
 		return err
 	}
-	err = setThinkTimeIfNotSet(&settings.AskHubAdvisorSettingsCore.ThinkTimeSettings, &askHubAdvisorDefaultThinktimeSettings)
-	if err != nil {
-		return err
-	}
+	settings.AskHubAdvisorSettingsCore.ThinkTimeSettings = thinkTimeWithFallback(
+		settings.AskHubAdvisorSettingsCore.ThinkTimeSettings,
+		askHubAdvisorDefaultThinktimeSettings,
+	)
 	switch settings.QuerySource {
 	case QueryFromFile:
 		if settings.FileName == "" {

--- a/scenario/helpers.go
+++ b/scenario/helpers.go
@@ -172,15 +172,10 @@ func (execute executeFunc) Validate() ([]string, error) {
 	return nil, nil
 }
 
-var internalSetThinkTimeError = errors.New("internal error: can not set thinkTime if **ThinkTimeSettings is nil")
-
-func setThinkTimeIfNotSet(thinkTime **ThinkTimeSettings, fallback *ThinkTimeSettings) error {
-	if thinkTime == nil {
-		return internalSetThinkTimeError
+func thinkTimeWithFallback(thinkTime *ThinkTimeSettings, fallback ThinkTimeSettings) *ThinkTimeSettings {
+	if thinkTime == nil || thinkTime.Type == helpers.StaticDistribution && thinkTime.Delay == 0 {
+		return &fallback
 	}
-	if *thinkTime == nil || (*thinkTime).Type == helpers.StaticDistribution && (*thinkTime).Delay == 0 {
-		*thinkTime = fallback
-		return nil
-	}
-	return nil
+	aCopy := *thinkTime
+	return &aCopy
 }

--- a/scenario/helpers.go
+++ b/scenario/helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/qlik-oss/gopherciser/action"
 	"github.com/qlik-oss/gopherciser/connection"
 	"github.com/qlik-oss/gopherciser/enigmahandlers"
+	"github.com/qlik-oss/gopherciser/helpers"
 	"github.com/qlik-oss/gopherciser/senseobjects"
 	"github.com/qlik-oss/gopherciser/session"
 )
@@ -169,4 +170,17 @@ func (execute executeFunc) Validate() ([]string, error) {
 		return nil, errors.New("executeFunc is nil")
 	}
 	return nil, nil
+}
+
+var internalSetThinkTimeError = errors.New("internal error: can not set thinkTime if **ThinkTimeSettings is nil")
+
+func setThinkTimeIfNotSet(thinkTime **ThinkTimeSettings, fallback *ThinkTimeSettings) error {
+	if thinkTime == nil {
+		return internalSetThinkTimeError
+	}
+	if *thinkTime == nil || (*thinkTime).Type == helpers.StaticDistribution && (*thinkTime).Delay == 0 {
+		*thinkTime = fallback
+		return nil
+	}
+	return nil
 }

--- a/scenario/helpers_test.go
+++ b/scenario/helpers_test.go
@@ -1,0 +1,90 @@
+package scenario
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/qlik-oss/gopherciser/helpers"
+)
+
+func checkThinkTimeEquality(expected, actual *ThinkTimeSettings) error {
+	if expected != actual || !reflect.DeepEqual(expected, actual) {
+		return errors.Errorf("expected address<%p> value<%#v>, got address<%p> value<%#v>", expected, expected, actual, actual)
+	}
+	return nil
+}
+func TestSetThinkTimeIfNotSet(t *testing.T) {
+	shallBeInternalSetThinkTimeError := func(err error) error {
+		if err != internalSetThinkTimeError {
+			return errors.Errorf("expected error %s, got error %s", internalSetThinkTimeError, err)
+		}
+		return nil
+	}
+	defaultThinkTime := &ThinkTimeSettings{}
+	var nilThinkTime *ThinkTimeSettings
+	nonDefaultThinkTime := &ThinkTimeSettings{
+		helpers.DistributionSettings{
+			Type:  helpers.StaticDistribution,
+			Delay: 0.0000000000001,
+		},
+	}
+	cases := []struct {
+		name     string
+		input    **ThinkTimeSettings
+		fallback *ThinkTimeSettings
+		checkErr func(actualErr error) error
+		shallSet bool
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			fallback: &askHubAdvisorDefaultThinktimeSettings,
+			checkErr: shallBeInternalSetThinkTimeError,
+		},
+		{
+			name:     "use fallback, cause default",
+			input:    &defaultThinkTime,
+			fallback: &askHubAdvisorDefaultThinktimeSettings,
+			shallSet: true,
+		},
+		{
+			name:     "use fallback, cause nil",
+			input:    &nilThinkTime,
+			fallback: &askHubAdvisorDefaultThinktimeSettings,
+			shallSet: true,
+		},
+		{
+			name:     "use input",
+			input:    &nonDefaultThinkTime,
+			fallback: &askHubAdvisorDefaultThinktimeSettings,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var inputBefore *ThinkTimeSettings
+			if c.input != nil {
+				inputBefore = *c.input
+			}
+			setThinkTimeErr := setThinkTimeIfNotSet(c.input, c.fallback)
+			if c.checkErr != nil {
+				if err := c.checkErr(setThinkTimeErr); err != nil {
+					t.Error(err)
+				}
+			}
+			if setThinkTimeErr != nil {
+				return
+			}
+			if c.shallSet {
+				if err := checkThinkTimeEquality(*c.input, c.fallback); err != nil {
+					t.Error(errors.Wrap(err, "not using fallback when should have"))
+				}
+			} else {
+				if err := checkThinkTimeEquality(*c.input, inputBefore); err != nil {
+					t.Error(errors.Wrap(err, "not using input when should have"))
+				}
+			}
+
+		})
+	}
+}

--- a/scenario/smartsearch.go
+++ b/scenario/smartsearch.go
@@ -150,10 +150,10 @@ func (settings *SmartSearchSettings) UnmarshalJSON(bytes []byte) error {
 	if err != nil {
 		return err
 	}
-	err = setThinkTimeIfNotSet(&settings.SmartSearchSettingsCore.SelectionThinkTime, &smartSearchDefaultThinktimeSettings)
-	if err != nil {
-		return err
-	}
+	settings.SmartSearchSettingsCore.SelectionThinkTime = thinkTimeWithFallback(
+		settings.SmartSearchSettingsCore.SelectionThinkTime,
+		smartSearchDefaultThinktimeSettings,
+	)
 	switch settings.SearchTextSource {
 	case SearchTextSourceList:
 	case SearchTextSourceFile:


### PR DESCRIPTION
This affects askhubadvisor and smartsearch. The reason for making the
check for deafults and nil is that the gui produces a json object with
static thinktime 0 by default, which is an invalid thinktime.

**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated
