### PR TITLE
Functions to issue a request once per session

### DIFF
--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -126,7 +126,7 @@ var (
 )
 
 // NewRestHandler new instance of RestHandler
-func NewRestHandler(ctx context.Context, size int, trafficLogger enigma.TrafficLogger, headerjar *HeaderJar, virtualProxy string, timeout time.Duration) *RestHandler {
+func NewRestHandler(ctx context.Context, trafficLogger enigma.TrafficLogger, headerjar *HeaderJar, virtualProxy string, timeout time.Duration) *RestHandler {
 	return &RestHandler{
 		reqCounter:     0,
 		reqCounterCond: sync.NewCond(&sync.Mutex{}),

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -273,6 +273,16 @@ func (handler *RestHandler) GetSync(url string, actionState *action.State, logEn
 	return handler.GetSyncWithCallback(url, actionState, logEntry, options, nil)
 }
 
+// GetSyncOnce same as GetSync but only called once in the same session
+func (handler *RestHandler) GetSyncOnce(url string, actionState *action.State, sessionState *State, logEntry *logger.LogEntry, options *ReqOptions) (*RestRequest, error) {
+	var req *RestRequest
+	var err error
+	sessionState.Once(fmt.Sprintf("GET %s", url), func() {
+		req, err = handler.GetSyncWithCallback(url, actionState, logEntry, options, nil)
+	})
+	return req, err
+}
+
 // GetSyncWithCallback sends synchronous GET request with options and callback, using options=nil default options are used
 func (handler *RestHandler) GetSyncWithCallback(url string, actionState *action.State, logEntry *logger.LogEntry, options *ReqOptions, callback func(err error, req *RestRequest)) (*RestRequest, error) {
 	var reqErr error
@@ -298,8 +308,7 @@ func (handler *RestHandler) GetAsync(url string, actionState *action.State, logE
 }
 
 // GetAsyncOnce same as GetAsync but only called once in the same session
-func (handler *RestHandler) GetAsyncOnce(url string, actionState *action.State, sessionState *State, logEntry *logger.LogEntry,
-	options *ReqOptions) *RestRequest {
+func (handler *RestHandler) GetAsyncOnce(url string, actionState *action.State, sessionState *State, logEntry *logger.LogEntry, options *ReqOptions) *RestRequest {
 	var req *RestRequest
 	sessionState.Once(fmt.Sprintf("GET %s", url), func() {
 		req = handler.getAsyncWithCallback(url, actionState, logEntry, nil, options, nil)

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -297,6 +297,16 @@ func (handler *RestHandler) GetAsync(url string, actionState *action.State, logE
 	return handler.getAsyncWithCallback(url, actionState, logEntry, nil, options, nil)
 }
 
+// GetAsyncOnce same as GetAsync but only called once in the same session
+func (handler *RestHandler) GetAsyncOnce(url string, actionState *action.State, sessionState *State, logEntry *logger.LogEntry,
+	options *ReqOptions) *RestRequest {
+	var req *RestRequest
+	sessionState.Once(fmt.Sprintf("GET %s", url), func() {
+		req = handler.getAsyncWithCallback(url, actionState, logEntry, nil, options, nil)
+	})
+	return req
+}
+
 // GetWithHeadersAsync send async GET request with headers and options, using options=nil default options are used
 func (handler *RestHandler) GetWithHeadersAsync(url string, actionState *action.State, logEntry *logger.LogEntry, headers map[string]string, options *ReqOptions, callback func(err error, req *RestRequest)) *RestRequest {
 	return handler.getAsyncWithCallback(url, actionState, logEntry, headers, options, callback)

--- a/session/resthandler_test.go
+++ b/session/resthandler_test.go
@@ -30,7 +30,7 @@ func TestResthandler(t *testing.T) {
 
 	actionState := action.State{}
 
-	restHandler := NewRestHandler(context.Background(), 32, &enigmahandlers.TrafficLogger{}, NewHeaderJar(), "", 10*time.Second)
+	restHandler := NewRestHandler(context.Background(), &enigmahandlers.TrafficLogger{}, NewHeaderJar(), "", 10*time.Second)
 	restHandler.Client = http.DefaultClient
 	getRequest := RestRequest{
 		Method:      GET,

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -1028,6 +1028,17 @@ func (state *State) GetCustomState(key string) (interface{}, bool) {
 	return value, exist
 }
 
+// Once executes the function with matching string once (per session)
+func (state *State) Once(key string, f func()) bool {
+	_, exists := state.GetCustomState(key)
+	if exists {
+		return false
+	}
+	state.AddCustomState(key, struct{}{})
+	f()
+	return true
+}
+
 // SetVariableValue to session variable map
 func (state *State) SetVariableValue(variable string, value interface{}) {
 	state.variablesLock.Lock()

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -278,7 +278,7 @@ func (state *State) SetLogEntry(entry *logger.LogEntry) {
 		state.trafficLogger = enigmahandlers.NewTrafficRequestCounter(state.Counters)
 	}
 
-	state.Rest = NewRestHandler(state.ctx, 64, state.trafficLogger, state.HeaderJar, state.VirtualProxy, state.Timeout)
+	state.Rest = NewRestHandler(state.ctx, state.trafficLogger, state.HeaderJar, state.VirtualProxy, state.Timeout)
 }
 
 // TrafficLogger returns the current trafficLogger

--- a/session/sessionstate_test.go
+++ b/session/sessionstate_test.go
@@ -213,7 +213,7 @@ func TestState_SessionVariables(t *testing.T) {
 func setupStateForCLTest() (*State, *eventCounter, *eventCounter, *eventCounter, *eventCounter) {
 	counters := &statistics.ExecutionCounters{}
 	state := New(context.Background(), "", 60, nil, 1, 1, "", false, counters)
-	state.Rest = NewRestHandler(state.ctx, 64, state.trafficLogger, state.HeaderJar, state.VirtualProxy, state.Timeout)
+	state.Rest = NewRestHandler(state.ctx, state.trafficLogger, state.HeaderJar, state.VirtualProxy, state.Timeout)
 
 	event0 := registerEvent(state, 0)
 	event1 := registerEvent(state, 1)


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Add helper function to execute a function only once in a session. Add GetAsyncOnce and GetSyncOnce for requests that are executed once per session.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
