### PR TITLE
change scatterplot binned breakpoint to new default of 2000

### DIFF
--- a/docs/sense-object-definitions.md
+++ b/docs/sense-object-definitions.md
@@ -270,7 +270,7 @@ An object that sends different data requests depending on the size of the data:
         "constraints": [
           {
             "path": "/qHyperCube/qSize/qcy",
-            "value": ">1000",
+            "value": ">2000",
             "required": true
           }
         ],

--- a/docs/sense-object-definitions.md
+++ b/docs/sense-object-definitions.md
@@ -286,7 +286,7 @@ An object that sends different data requests depending on the size of the data:
           {
             "type": "hypercubedata",
             "path": "/qHyperCubeDef",
-            "height": 1000
+            "height": 2000
           }
         ]
       }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Scatter plot is now sending binned data request at break point 2000 instead of 1000.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
