### PR TITLE
Add option to ignore publishing already published sheets

### DIFF
--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -1288,6 +1288,7 @@ Publish sheets in the current app.
     * `allsheets`: Publish all sheets in the app.
     * `sheetids`: Only publish the sheets specified by the `sheetIds` array.
 * `sheetIds`: (optional) Array of sheet IDs for the `sheetids` mode.
+* `ignorePublished`: Do not try to publish already published sheets.
 
 ### Example
 ```json

--- a/docs/settingup.md
+++ b/docs/settingup.md
@@ -1288,7 +1288,7 @@ Publish sheets in the current app.
     * `allsheets`: Publish all sheets in the app.
     * `sheetids`: Only publish the sheets specified by the `sheetIds` array.
 * `sheetIds`: (optional) Array of sheet IDs for the `sheetids` mode.
-* `ignorePublished`: Do not try to publish already published sheets.
+* `includePublished`: Try to publish already published sheets.
 
 ### Example
 ```json

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -449,6 +449,9 @@
     "publishsheet.sheetIds": [
         "(optional) Array of sheet IDs for the `sheetids` mode."
     ],
+    "publishsheet.ignorePublished": [
+        "Do not try to publish already published sheets."
+    ],
     "randomaction.iterations": [
         "Number of random actions to perform."
     ],

--- a/generatedocs/data/params.json
+++ b/generatedocs/data/params.json
@@ -449,8 +449,8 @@
     "publishsheet.sheetIds": [
         "(optional) Array of sheet IDs for the `sheetids` mode."
     ],
-    "publishsheet.ignorePublished": [
-        "Do not try to publish already published sheets."
+    "publishsheet.includePublished": [
+        "Try to publish already published sheets."
     ],
     "randomaction.iterations": [
         "Number of random actions to perform."

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -301,7 +301,7 @@ var (
 		"openapp.externalhost":                            {"(optional) Sets an external host to be used instead of `server` configured in connection settings."},
 		"openapp.unique":                                  {"Create unqiue engine session not re-using session from previous connection with same user. Defaults to false."},
 		"productversion.log":                              {"Save the product version to the log (`true` / `false`). Defaults to `false`, if omitted."},
-		"publishsheet.ignorePublished":                    {"Do not try to publish already published sheets."},
+		"publishsheet.includePublished":                   {"Try to publish already published sheets."},
 		"publishsheet.mode":                               {"", "`allsheets`: Publish all sheets in the app.", "`sheetids`: Only publish the sheets specified by the `sheetIds` array."},
 		"publishsheet.sheetIds":                           {"(optional) Array of sheet IDs for the `sheetids` mode."},
 		"randomaction.actions":                            {"List of actions from which to randomly pick an action to execute. Each item has a number of possible parameters."},

--- a/generatedocs/generated/documentation.go
+++ b/generatedocs/generated/documentation.go
@@ -301,6 +301,7 @@ var (
 		"openapp.externalhost":                            {"(optional) Sets an external host to be used instead of `server` configured in connection settings."},
 		"openapp.unique":                                  {"Create unqiue engine session not re-using session from previous connection with same user. Defaults to false."},
 		"productversion.log":                              {"Save the product version to the log (`true` / `false`). Defaults to `false`, if omitted."},
+		"publishsheet.ignorePublished":                    {"Do not try to publish already published sheets."},
 		"publishsheet.mode":                               {"", "`allsheets`: Publish all sheets in the app.", "`sheetids`: Only publish the sheets specified by the `sheetIds` array."},
 		"publishsheet.sheetIds":                           {"(optional) Array of sheet IDs for the `sheetids` mode."},
 		"randomaction.actions":                            {"List of actions from which to randomly pick an action to execute. Each item has a number of possible parameters."},

--- a/scenario/publishsheet.go
+++ b/scenario/publishsheet.go
@@ -67,7 +67,10 @@ func (publishSheetSettings PublishSheetSettings) Execute(sessionState *session.S
 	publishAction := func(sheet *senseobjects.Sheet, ctx context.Context) error {
 		if publishSheetSettings.IgnorePublished {
 			if sheet.Layout.Meta.Published {
-				sessionState.LogDebugf(`not publishing sheet<%s> "%s" since it is already published`, sheet.ID, sheet.Layout.Meta.Title)
+				sessionState.LogDebugf(
+					`not publishing sheet<%s> "%s" since it is already published`,
+					sheet.ID, sheet.Layout.Meta.Title,
+				)
 				return nil
 			}
 		}
@@ -78,11 +81,15 @@ func (publishSheetSettings PublishSheetSettings) Execute(sessionState *session.S
 
 		sessionState.LogDebugf(`publishing %s sheet<%s> "%s"`, sheetAccessLevel, sheet.ID, sheet.Layout.Meta.Title)
 
-		return errors.Wrapf(
-			sheet.GenericObject.Publish(ctx),
-			`failed to publish %s sheet<%s> "%s"`,
-			sheetAccessLevel, sheet.ID, sheet.Layout.Meta.Title,
-		)
+		err := sheet.GenericObject.Publish(ctx)
+		if err != nil {
+			return errors.Wrapf(
+				err,
+				`failed to publish %s sheet<%s> "%s"`,
+				sheetAccessLevel, sheet.ID, sheet.Layout.Meta.Title,
+			)
+		}
+		return nil
 	}
 
 	executePubUnPubAction(publishSheetSettings.Mode, publishSheetSettings.SheetIDs,

--- a/scenario/publishsheet_test.go
+++ b/scenario/publishsheet_test.go
@@ -66,12 +66,12 @@ func TestValidatePublishSheetSettings(t *testing.T) {
 		input   PublishSheetSettings
 		isValid bool
 	}{
-		{PublishSheetSettings{AllSheets, nil}, true},
-		{PublishSheetSettings{AllSheets, []string{"A", "B", "C"}}, false},
-		{PublishSheetSettings{AllSheets, []string{}}, true},
-		{PublishSheetSettings{SheetIDs, nil}, false},
-		{PublishSheetSettings{SheetIDs, []string{}}, false},
-		{PublishSheetSettings{SheetIDs, []string{"A", "B", "C"}}, true},
+		{PublishSheetSettings{AllSheets, nil, false}, true},
+		{PublishSheetSettings{AllSheets, []string{"A", "B", "C"}, false}, false},
+		{PublishSheetSettings{AllSheets, []string{}, true}, true},
+		{PublishSheetSettings{SheetIDs, nil, false}, false},
+		{PublishSheetSettings{SheetIDs, []string{}, true}, false},
+		{PublishSheetSettings{SheetIDs, []string{"A", "B", "C"}, false}, true},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [x] documentation updated


**Squash commit message**

Add option to ignore publishing already published sheets

- Add some sheet access debug logging
- Decorate publish sheet error

**Info**

Publishing a public sheet give a generic access denied error, which was hard to trace. Some exported apps can have public sheets when uploaded again, which lead to the finding of this issue. I have not seen this behavior until this week, have you guys seen it before or is it new?
