### PR TITLE
add option to print result json to validate command

### DIFF
--- a/cmd/script.go
+++ b/cmd/script.go
@@ -17,6 +17,9 @@ var (
 	// structure command parameters
 	outputFolder string
 	includeRaw   bool
+
+	// validate command parameters
+	printJSON bool
 )
 
 func init() {
@@ -26,6 +29,7 @@ func init() {
 	// validate sub command
 	scriptCmd.AddCommand(validateCmd)
 	AddAllSharedParameters(validateCmd)
+	validateCmd.Flags().BoolVarP(&printJSON, "print", "p", false, "Print result JSON.")
 
 	// connect sub command
 	scriptCmd.AddCommand(testConnectionCmd)
@@ -108,13 +112,21 @@ var validateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := unmarshalConfigFile()
 		if err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return
 		}
 
 		if err := validateConfigAndPrintWarnings(cfg); err != nil {
-			_, _ = fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
+			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			return
+		}
+
+		if printJSON {
+			result, err := json.MarshalIndent(cfg, "", "  ")
+			if err != nil {
+				_, _ = os.Stderr.WriteString(fmt.Sprintf("failed to marshal result JSON, err: %v\n", err))
+			}
+			fmt.Println(string(result))
 		}
 
 		_, _ = os.Stderr.WriteString("Config Valid!\n")


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Add option to print result JSON to stdout with validate command. All other messages are printed to stderr so 

```bash
gopherciser s v -c script.json -p > result.json
```
will have the json after unmarshal (which can be diff'ed towards original)

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
