### PR TITLE
WS Reconnect changes

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -118,7 +118,7 @@ func (connectionSettings *ConnectionSettings) Validate() error {
 }
 
 // GetConnectFunc Get function for connecting to sense
-func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID, externalhost string, customHeaders http.Header) (func() (string, error), error) {
+func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID, externalhost string, customHeaders http.Header) (func(bool) (string, error), error) {
 	header, err := connectionSettings.GetHeaders(state, externalhost)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/connection/connection.go
+++ b/connection/connection.go
@@ -48,6 +48,10 @@ type (
 		syncTemplates sync.Once
 		templates     map[string]*template.Template
 	}
+
+	// ConnectFunc connects to a sense environment, set reconnect to true if it's a reconnect and session in engine
+	// is expected. Returns App GUID.
+	ConnectFunc func(reconnect bool) (string, error)
 )
 
 const (
@@ -118,7 +122,7 @@ func (connectionSettings *ConnectionSettings) Validate() error {
 }
 
 // GetConnectFunc Get function for connecting to sense
-func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID, externalhost string, customHeaders http.Header) (func(bool) (string, error), error) {
+func (connectionSettings *ConnectionSettings) GetConnectFunc(state *session.State, appGUID, externalhost string, customHeaders http.Header) (ConnectFunc, error) {
 	header, err := connectionSettings.GetHeaders(state, externalhost)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/connection/jwtconnection.go
+++ b/connection/jwtconnection.go
@@ -53,7 +53,7 @@ type (
 )
 
 // GetConnectFunc which establishes a connection to Qlik Sense
-func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func(bool) (string, error) {
+func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) ConnectFunc {
 	connectFunc := func(reconnect bool) (string, error) {
 		url, err := connection.GetURL(appGUID, externalhost)
 		if err != nil {

--- a/connection/jwtconnection.go
+++ b/connection/jwtconnection.go
@@ -69,7 +69,6 @@ func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State
 
 		sense := enigmahandlers.NewSenseUplink(sessionState.BaseContext(), sessionState.LogEntry, sessionState.RequestMetrics, sessionState.TrafficLogger())
 		sessionState.Connection.SetSense(sense)
-		sense.OnUnexpectedDisconnect(sessionState.WSFailed)
 
 		// Connect
 		ctx, cancel := sessionState.ContextWithTimeout(sessionState.BaseContext())
@@ -93,6 +92,7 @@ func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State
 		if err = sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout, reconnect); err != nil {
 			return appGUID, errors.WithStack(err)
 		}
+		sense.OnUnexpectedDisconnect(sessionState.WSFailed)
 
 		return appGUID, nil
 	}

--- a/connection/jwtconnection.go
+++ b/connection/jwtconnection.go
@@ -53,8 +53,8 @@ type (
 )
 
 // GetConnectFunc which establishes a connection to Qlik Sense
-func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func() (string, error) {
-	connectFunc := func() (string, error) {
+func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State, connection *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func(bool) (string, error) {
+	connectFunc := func(reconnect bool) (string, error) {
 		url, err := connection.GetURL(appGUID, externalhost)
 		if err != nil {
 			return appGUID, errors.WithStack(err)
@@ -90,7 +90,7 @@ func (connectJWT *ConnectJWTSettings) GetConnectFunc(sessionState *session.State
 		for k, v := range customHeaders {
 			connectHeaders[k] = v
 		}
-		if err = sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout); err != nil {
+		if err = sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connection.Allowuntrusted, sessionState.Timeout, reconnect); err != nil {
 			return appGUID, errors.WithStack(err)
 		}
 

--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -15,8 +15,8 @@ type (
 )
 
 // GetConnectFunc get ws connect function
-func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func() (string, error) {
-	return func() (string, error) {
+func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func(bool) (string, error) {
+	return func(reconnect bool) (string, error) {
 		if sessionState == nil {
 			return appGUID, errors.New("Session state is nil")
 		}
@@ -56,7 +56,7 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 			connectHeaders[k] = v
 		}
 
-		if err := sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout); err != nil {
+		if err := sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout, reconnect); err != nil {
 			return appGUID, errors.Wrap(err, "Failed connecting to sense server")
 		}
 

--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -29,7 +29,6 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 
 		sense := enigmahandlers.NewSenseUplink(sessionState.BaseContext(), sessionState.LogEntry, sessionState.RequestMetrics, sessionState.TrafficLogger())
 		sessionState.Connection.SetSense(sense)
-		sense.OnUnexpectedDisconnect(sessionState.WSFailed)
 
 		url, err := connectionSettings.GetURL(appGUID, externalhost)
 		if err != nil {
@@ -59,6 +58,8 @@ func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, 
 		if err := sense.Connect(ctx, url, connectHeaders, sessionState.Cookies, connectionSettings.Allowuntrusted, sessionState.Timeout, reconnect); err != nil {
 			return appGUID, errors.Wrap(err, "Failed connecting to sense server")
 		}
+
+		sense.OnUnexpectedDisconnect(sessionState.WSFailed)
 
 		return appGUID, nil
 	}

--- a/connection/wsconnection.go
+++ b/connection/wsconnection.go
@@ -15,7 +15,7 @@ type (
 )
 
 // GetConnectFunc get ws connect function
-func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) func(bool) (string, error) {
+func (connectWs *ConnectWsSettings) GetConnectFunc(sessionState *session.State, connectionSettings *ConnectionSettings, appGUID, externalhost string, headers, customHeaders http.Header) ConnectFunc {
 	return func(reconnect bool) (string, error) {
 		if sessionState == nil {
 			return appGUID, errors.New("Session state is nil")

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -212,9 +212,6 @@ func (uplink *SenseUplink) Connect(ctx context.Context, url string, headers http
 	uplink.Global = global
 
 	if !uplink.MockMode {
-		// send a quick request, after this OnConnected and EventTopicOnAuthenticationInformation has been done and websocket possibly force closed
-		_, connectErr := global.EngineVersion(uplink.ctx)
-
 		mustAuthenticate, onConnectedSessionState, otherTopics := emptyMsgChan(connectMsgChan, uplink.logEntry)
 
 		if mustAuthenticate != nil && *mustAuthenticate {
@@ -242,6 +239,8 @@ func (uplink *SenseUplink) Connect(ctx context.Context, url string, headers http
 			return errors.Errorf("websocket connected, but received error topic/-s: %s", strings.Join(otherTopics, ","))
 		}
 
+		// send a quick request, after this OnConnected and EventTopicOnAuthenticationInformation has been done and websocket possibly force closed
+		_, connectErr := global.EngineVersion(uplink.ctx)
 		if connectErr != nil {
 			// no mustAuthenticate, no onConnectedSessionState, and no other topics, post the connectErr (although it's most likely just EOF...)
 			return errors.Errorf("websocket connected, but got error on requesting version: %v", connectErr)

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -212,10 +212,6 @@ func (uplink *SenseUplink) Connect(ctx context.Context, url string, headers http
 // Disconnect Sense connection
 func (uplink *SenseUplink) Disconnect() {
 	uplink.cancel()
-	isConnected := uplink.IsConnected()
-	if uplink.logEntry != nil {
-		uplink.logEntry.LogDebugf("Disconnect websocket connected: %v", isConnected)
-	}
 	if uplink.Global != nil {
 		uplink.Global.DisconnectFromServer()
 	}

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -32,11 +32,11 @@ type (
 		VarCache   VarCache
 		Traffic    ITrafficLogger
 
-		ctx                context.Context
-		cancel             context.CancelFunc
-		logEntry           *logger.LogEntry
-		trafficMetrics     *requestmetrics.RequestMetrics
-		failedConnectFuncs []func()
+		ctx               context.Context
+		cancel            context.CancelFunc
+		logEntry          *logger.LogEntry
+		trafficMetrics    *requestmetrics.RequestMetrics
+		failedConnectFunc func()
 
 		MockMode bool
 	}
@@ -309,20 +309,14 @@ func (uplink *SenseUplink) OnUnexpectedDisconnect(f func()) {
 		return
 	}
 
-	if uplink.failedConnectFuncs == nil {
-		uplink.failedConnectFuncs = make([]func(), 0, 1)
-	}
-
-	uplink.failedConnectFuncs = append(uplink.failedConnectFuncs, f)
+	uplink.failedConnectFunc = f
 }
 
 func (uplink *SenseUplink) executeFailedConnectFuncs() {
-	if uplink == nil || len(uplink.failedConnectFuncs) < 1 {
+	if uplink == nil || uplink.failedConnectFunc == nil {
 		return
 	}
-	for _, f := range uplink.failedConnectFuncs {
-		f()
-	}
+	uplink.failedConnectFunc()
 }
 
 // LogMetric async log metric, this is injected into the enigma dialer and is responsible for recording

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -259,7 +259,7 @@ func emptyMsgChan(msgChan chan enigma.SessionMessage, logEntry *logger.LogEntry)
 	otherTopics := make([]string, 0, 1)
 
 	recievedAtLeastOne := false
-	for i := 0; i < 500; i++ { // Waiting up to 500 ms for a session message to be be pushed, checking each 1ms
+	for i := 0; i < 30*1000; i++ { // Waiting up to 30 s for a session message to be be pushed, checking each 1ms
 		select {
 		case event, ok := <-msgChan:
 			recievedAtLeastOne = true

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -214,7 +214,7 @@ func (uplink *SenseUplink) Disconnect() {
 	uplink.cancel()
 	isConnected := uplink.IsConnected()
 	if uplink.logEntry != nil {
-		uplink.logEntry.LogDebugf("websocket connected:", isConnected)
+		uplink.logEntry.LogDebugf("Disconnect websocket connected: %v", isConnected)
 	}
 	if uplink.Global != nil && uplink.IsConnected() {
 		uplink.Global.DisconnectFromServer()

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -260,7 +260,7 @@ func emptyMsgChan(msgChan chan enigma.SessionMessage, logEntry *logger.LogEntry)
 	otherTopics := make([]string, 0, 1)
 
 	recievedAtLeastOne := false
-	for i := 0; i < 100; i++ { // Waiting up to 100 ms for a session message to be be pushed, checking each 1ms
+	for i := 0; i < 500; i++ { // Waiting up to 500 ms for a session message to be be pushed, checking each 1ms
 		select {
 		case event, ok := <-msgChan:
 			recievedAtLeastOne = true

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -212,6 +212,10 @@ func (uplink *SenseUplink) Connect(ctx context.Context, url string, headers http
 // Disconnect Sense connection
 func (uplink *SenseUplink) Disconnect() {
 	uplink.cancel()
+	isConnected := uplink.IsConnected()
+	if uplink.logEntry != nil {
+		uplink.logEntry.LogDebugf("websocket connected:", isConnected)
+	}
 	if uplink.Global != nil && uplink.IsConnected() {
 		uplink.Global.DisconnectFromServer()
 	}

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -212,8 +212,21 @@ func (uplink *SenseUplink) Connect(ctx context.Context, url string, headers http
 // Disconnect Sense connection
 func (uplink *SenseUplink) Disconnect() {
 	uplink.cancel()
-	if uplink.Global != nil {
+	if uplink.Global != nil && uplink.IsConnected() {
 		uplink.Global.DisconnectFromServer()
+	}
+}
+
+// IsConnected returns true if uplink is live
+func (uplink *SenseUplink) IsConnected() bool {
+	if uplink == nil || uplink.Global == nil {
+		return false
+	}
+	select {
+	case <-uplink.Global.Disconnected():
+		return false
+	default:
+		return true
 	}
 }
 

--- a/enigmahandlers/senseconnect.go
+++ b/enigmahandlers/senseconnect.go
@@ -216,7 +216,7 @@ func (uplink *SenseUplink) Disconnect() {
 	if uplink.logEntry != nil {
 		uplink.logEntry.LogDebugf("Disconnect websocket connected: %v", isConnected)
 	}
-	if uplink.Global != nil && uplink.IsConnected() {
+	if uplink.Global != nil {
 		uplink.Global.DisconnectFromServer()
 	}
 }

--- a/enigmahandlers/senseconnect_test.go
+++ b/enigmahandlers/senseconnect_test.go
@@ -13,7 +13,7 @@ func TestConnection(t *testing.T) {
 	connection := NewSenseUplink(context.Background(), nil, &requestmetrics.RequestMetrics{}, nil)
 	connection.MockMode = true
 
-	if err := connection.Connect(context.Background(), "wss://localhost", nil, nil, false, 0); err != nil {
+	if err := connection.Connect(context.Background(), "wss://localhost", nil, nil, false, 0, false); err != nil {
 		t.Error(err)
 	}
 }

--- a/enigmahandlers/topichandler.go
+++ b/enigmahandlers/topichandler.go
@@ -66,6 +66,7 @@ func (handler *topicsHandler) Start(logEntry *logger.LogEntry) {
 				}
 				handler.mustAuthenticate = &onAuthInfo.MustAuthenticate
 			default:
+				logEntry.LogDebugf("unhandled connect topic<%s> content<%s>", event.Topic, string(event.Content))
 				handler.otherTopics = append(handler.otherTopics, event.Topic)
 			}
 		}

--- a/enigmahandlers/topichandler.go
+++ b/enigmahandlers/topichandler.go
@@ -1,0 +1,104 @@
+package enigmahandlers
+
+import (
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/pkg/errors"
+	"github.com/qlik-oss/enigma-go/v3"
+	"github.com/qlik-oss/gopherciser/globals/constant"
+	"github.com/qlik-oss/gopherciser/logger"
+)
+
+type (
+	// OnAuthenticationInformation content structure of OnAuthenticationInformation event
+	OnAuthenticationInformation struct {
+		// MustAuthenticate tells us if we are authenticated
+		MustAuthenticate bool `json:"mustAuthenticate"`
+	}
+
+	// OnConnected content structure of EventTopicOnConnected event
+	OnConnected struct {
+		// SessionState received session state, possible states listed as constants in constant.EventTopicOnConnected*
+		SessionState string `json:"qSessionState"`
+	}
+
+	topicsHandler struct {
+		msgChannel              chan enigma.SessionMessage
+		OnConnectedReceived     chan struct{}
+		mustAuthenticate        *bool
+		onConnectedSessionState *string
+		otherTopics             []string
+	}
+)
+
+// NewTopicsHandler handles pusched topics on message channel
+func NewTopicsHandler(channel chan enigma.SessionMessage) *topicsHandler {
+	return &topicsHandler{
+		msgChannel:          channel,
+		OnConnectedReceived: make(chan struct{}),
+		otherTopics:         make([]string, 0),
+	}
+}
+
+// Start topics handler and return channel messaging when OnConnected topic is received
+func (handler *topicsHandler) Start(logEntry *logger.LogEntry) {
+	go func() {
+		for event := range handler.msgChannel {
+			switch event.Topic {
+			case constant.EventTopicOnConnected:
+				logEntry.LogInfo("OnConnected", string(event.Content))
+
+				var onConnected OnConnected
+				var sessionState string
+				if err := json.Unmarshal(event.Content, &onConnected); err != nil {
+					sessionState = constant.OnConnectedSessionSessionParseFailed
+				} else {
+					sessionState = onConnected.SessionState
+				}
+				handler.onConnectedSessionState = &sessionState
+				close(handler.OnConnectedReceived)
+			case constant.EventTopicOnAuthenticationInformation:
+				var onAuthInfo OnAuthenticationInformation
+				if err := json.Unmarshal(event.Content, &onAuthInfo); err != nil {
+					logEntry.Log(logger.WarningLevel, "failed to unmarshal pushed OnAuthenticationInformation message")
+					continue
+				}
+				handler.mustAuthenticate = &onAuthInfo.MustAuthenticate
+			default:
+				handler.otherTopics = append(handler.otherTopics, event.Topic)
+			}
+		}
+	}()
+}
+
+func (handler *topicsHandler) IsErrorState(reconnect bool, logEntry *logger.LogEntry) error {
+	if handler.mustAuthenticate != nil && *handler.mustAuthenticate {
+		return errors.Errorf("websocket connected, but authentication failed")
+	}
+
+	if handler.onConnectedSessionState != nil {
+		switch *handler.onConnectedSessionState {
+		case constant.OnConnectedSessionSessionParseFailed:
+			return errors.New("failed to parse OnConnected pushed message")
+		case constant.OnConnectedSessionCreated, constant.OnConnectedSessionAttached:
+			if reconnect && *handler.onConnectedSessionState != constant.OnConnectedSessionAttached {
+				return NoSessionOnReconnectError{}
+			}
+			return nil // connected ok
+		case constant.OnConnectedSessionErrorNoLicense, constant.OnConnectedSessionErrorLicenseReNew, constant.OnConnectedSessionErrorLimitExceeded,
+			constant.OnConnectedSessionErrorSecurityHeaderChanged, constant.OnConnectedSessionAccessControlSetupFailure, constant.OnConnectedSessionErrorAppAccessDenied,
+			constant.OnConnectedSessionErrorAppFailure: // known error states
+			return errors.Errorf("error connecting to engine: %s", *handler.onConnectedSessionState)
+		default:
+			logEntry.Logf(logger.WarningLevel, "unknown engine session state: %s", *handler.onConnectedSessionState)
+		}
+	}
+
+	// No OnConnected received, return list of "other" topics
+	if len(handler.otherTopics) > 0 {
+		return errors.Errorf("websocket connected, but received error topic/-s: %s", strings.Join(handler.otherTopics, ","))
+	}
+
+	return nil
+}

--- a/globals/constant/topics.go
+++ b/globals/constant/topics.go
@@ -22,6 +22,8 @@ const (
 
 // EventTopicOnConnected possible states
 const (
+	OnConnectedSessionSessionParseFailed = "SessionStateParseFailed" // Not actually sent by engine but set when parsing of message failed
+
 	OnConnectedSessionCreated                    = "SESSION_CREATED"
 	OnConnectedSessionAttached                   = "SESSION_ATTACHED"
 	OnConnectedSessionErrorNoLicense             = "SESSION_ERROR_NO_LICENSE"

--- a/scenario/openapp.go
+++ b/scenario/openapp.go
@@ -28,7 +28,7 @@ type (
 	}
 
 	connectWsSettings struct {
-		ConnectFunc func() (string, error)
+		ConnectFunc func(bool) (string, error)
 	}
 )
 
@@ -197,7 +197,7 @@ func openDoc(ctx context.Context, uplink *enigmahandlers.SenseUplink, appGUID st
 	return uplink.SetCurrentApp(appGUID, doc)
 }
 
-func (openApp OpenAppSettings) GetConnectWsAction(wsLabel string, connectFunc func() (string, error)) Action {
+func (openApp OpenAppSettings) GetConnectWsAction(wsLabel string, connectFunc func(bool) (string, error)) Action {
 	connectWs := Action{
 		ActionCore{
 			Type:  ActionConnectWs,
@@ -219,7 +219,7 @@ func (openApp OpenAppSettings) AppStructureAction() (*AppStructureInfo, []Action
 }
 
 func (connectWs connectWsSettings) Execute(sessionState *session.State, actionState *action.State, connectionSettings *connection.ConnectionSettings, label string, reset func()) {
-	appGUID, err := connectWs.ConnectFunc()
+	appGUID, err := connectWs.ConnectFunc(false)
 	if err != nil {
 		actionState.AddErrors(errors.Wrap(err, "Failed connecting to sense server"))
 		return

--- a/session/appfunctions.go
+++ b/session/appfunctions.go
@@ -11,18 +11,22 @@ import (
 	"github.com/qlik-oss/gopherciser/senseobjects"
 )
 
-// GetActiveDoc get active doc from engine
-func (state *State) GetActiveDoc(actionState *action.State, upLink *enigmahandlers.SenseUplink) (*enigma.Doc, error) {
+// ReOpenDoc get active doc from engine
+func (state *State) ReOpenDoc(actionState *action.State, upLink *enigmahandlers.SenseUplink) (*enigma.Doc, error) {
+
+	if state.CurrentApp == nil || state.CurrentApp.ID == "" {
+		return nil, errors.Errorf("ReOpenDoc: no current app set in state")
+	}
+
 	var doc *enigma.Doc
 	err := state.SendRequest(actionState, func(ctx context.Context) error {
-		activeDoc, err := upLink.Global.GetActiveDoc(ctx)
+		var err error
+		doc, err = upLink.Global.OpenDoc(ctx, state.CurrentApp.ID, "", "", "", false)
 		if err != nil {
 			return errors.WithStack(NoActiveDocError{Err: err})
-		} else if activeDoc == nil {
-			return errors.WithStack(NoActiveDocError{Msg: "No Active doc found on reconnect."})
+		} else if doc == nil {
+			return errors.WithStack(NoActiveDocError{Msg: "No doc found on reconnect."})
 		}
-
-		doc = activeDoc
 		return nil
 	})
 	return doc, errors.WithStack(err)

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -664,7 +664,13 @@ func (state *State) WSFailed() {
 
 			panicErr := helpers.RecoverWithErrorFunc(func() {
 				if err := state.Reconnect(); err != nil {
-					state.LogEntry.LogError(errors.Wrap(err, "failed to reconnect websocket and app"))
+					err = errors.Wrap(err, "failed to reconnect websocket and app")
+					actionState := state.CurrentActionState
+					if actionState != nil {
+						actionState.AddErrors(err)
+					} else {
+						state.LogEntry.LogError(err)
+					}
 					state.Cancel()
 					return
 				}
@@ -853,7 +859,7 @@ func (state *State) IsSenseWebsocketDisconnected(err error) bool {
 	return false
 }
 
-//CurrentSenseApp returns currently set sense app or error if none found
+// CurrentSenseApp returns currently set sense app or error if none found
 func (state *State) CurrentSenseApp() (*senseobjects.App, error) {
 	uplink, err := state.CurrentSenseUplink()
 	if err != nil {

--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -122,7 +122,7 @@ type (
 	ReconnectInfo struct {
 		err                 error
 		pendingReconnection pending.Handler
-		reconnectFunc       func() (string, error)
+		reconnectFunc       func(bool) (string, error)
 	}
 
 	// SessionVariables is used as a data carrier for session variables.
@@ -665,12 +665,7 @@ func (state *State) WSFailed() {
 			panicErr := helpers.RecoverWithErrorFunc(func() {
 				if err := state.Reconnect(); err != nil {
 					err = errors.Wrap(err, "failed to reconnect websocket and app")
-					actionState := state.CurrentActionState
-					if actionState != nil {
-						actionState.AddErrors(err)
-					} else {
-						state.LogEntry.LogError(err)
-					}
+					state.LogEntry.LogError(err) // report error directly since errors on "Cancel" will be igonored
 					state.Cancel()
 					return
 				}
@@ -780,9 +775,15 @@ reconnectLoop:
 		reConnectActionState := &action.State{}
 
 		attempts = i + 1
-		if _, err := state.reconnect.reconnectFunc(); err != nil {
-			state.reconnect.err = errors.Wrap(err, "Failed connecting to sense server")
-			continue reconnectLoop
+		if _, err := state.reconnect.reconnectFunc(true); err != nil {
+			switch helpers.TrueCause(err).(type) {
+			case enigmahandlers.NoSessionOnReconnectError:
+				state.reconnect.err = errors.WithStack(err)
+				break reconnectLoop
+			default:
+				state.reconnect.err = errors.Wrap(err, "Failed connecting to sense server")
+				continue reconnectLoop
+			}
 		}
 
 		if err := state.SetupChangeChan(); err != nil {
@@ -792,7 +793,7 @@ reconnectLoop:
 
 		upLink := state.Connection.Sense()
 
-		doc, err := state.GetActiveDoc(reConnectActionState, upLink)
+		doc, err := state.ReOpenDoc(reConnectActionState, upLink)
 		if err != nil {
 			state.reconnect.err = errors.WithStack(err)
 			break reconnectLoop // no active doc, don't try re connecting again
@@ -838,7 +839,7 @@ reconnectLoop:
 }
 
 // SetReconnectFunc sets current app re-connect function
-func (state *State) SetReconnectFunc(f func() (string, error)) {
+func (state *State) SetReconnectFunc(f func(bool) (string, error)) {
 	if state == nil {
 		return
 	}
@@ -856,6 +857,7 @@ func (state *State) IsSenseWebsocketDisconnected(err error) bool {
 	if ok && disconnectErr.Type == enigmahandlers.SenseWsType {
 		return true
 	}
+
 	return false
 }
 


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

* Add reconnect errors to current state if existing, instead of separate error log
* Only allow one reconnect function on websocket reconnect.
* Rewrite connect/re-connect to look at session_created, session_attached pushed messages

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
