### PR TITLE
Expose artifact map in session variables

### DIFF
--- a/session/sessionstate.go
+++ b/session/sessionstate.go
@@ -132,6 +132,7 @@ type (
 		Thread     uint64
 		ScriptVars map[string]interface{}
 		Local      interface{}
+		Artifacts  *TemplateArtifactMap
 	}
 
 	ObjectHandlerInstance interface {
@@ -601,6 +602,20 @@ func (state *State) TriggerContextChanges(ctx context.Context, actionState *acti
 	state.TriggerEvents(actionState, cl.Changed, cl.Closed)
 }
 
+type (
+	TemplateArtifactMap struct {
+		artifactMap *ArtifactMap
+	}
+)
+
+func (artifacts *TemplateArtifactMap) GetIDByTypeAndName(artifactType, name string) (string, error) {
+	artifact, err := artifacts.artifactMap.Lookup(artifactType, name, ArtifactEntryCompareTypeName)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+	return artifact.ID, nil
+}
+
 // GetSessionVariable populates and returns session variables struct
 func (state *State) GetSessionVariable(localData interface{}) SessionVariables {
 	if state == nil {
@@ -620,6 +635,7 @@ func (state *State) GetSessionVariable(localData interface{}) SessionVariables {
 		Thread:     thread,
 		Local:      localData,
 		ScriptVars: state.variables,
+		Artifacts:  &TemplateArtifactMap{state.ArtifactMap},
 	}
 
 	if state.User != nil {


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Expose artifact map in session variables

This will enable using resource ids in templates, e-g:
```json
{
  "action": "setscriptvar",
  "settings": {
    "name": "MyAppId",
    "type": "string",
    "value": "{{.Artifacts.GetIDByTypeAndName \"app\" (print \"an-app-\" .Session)}}"
  }
}
```

**Info**

