### PR TITLE
Switch to dependabot instead of renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-	"enabled": true,
-	"postUpdateOptions": [
-		"gomodUpdateImportPaths"
-	]
-}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Switch to dependabot instead of renovate

**Info**

renovate seems to have stopped doing PR's and don't have access to config the app.
