### PR TITLE
Bugfix: log file .ConfigFile variable with multiple .'s in name

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -418,7 +418,7 @@ func execute() error {
 	// Data for variable templates
 	templateData := struct {
 		ConfigFile string
-	}{strings.Split(filepath.Base(cfgFile), ".")[0]}
+	}{strings.TrimRight(filepath.Base(cfgFile), "."+filepath.Ext(cfgFile))}
 
 	// === start execution ===
 	var msgErrorReachedMsg *string


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Now supports log file .ConfigFile variable with multiple .'s in name

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
