### PR TITLE
add specific traffic metric entry for event streaming

### DIFF
--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -634,6 +634,7 @@ func (handler *RestHandler) QueueRequestWithCallback(actionState *action.State, 
 			failRequest(errors.WithStack(err))
 			return
 		}
+		doTs := time.Now()
 		request.response, errRequest = handler.Client.Do(req)
 		if errRequest != nil {
 			WarnOrError(actionState, logEntry, failOnError, errors.Wrap(errRequest, "HTTP request fail"))
@@ -648,6 +649,10 @@ func (handler *RestHandler) QueueRequestWithCallback(actionState *action.State, 
 			request.ResponseStatusCode = request.response.StatusCode
 			request.ResponseHeaders = request.response.Header
 			request.ResponseBody, errRequest = io.ReadAll(request.response.Body)
+			// When content type is a stream normal metric log will be time to response without starting to stream the body. Thus this will log response time to stream end
+			if logEntry.ShouldLogTrafficMetrics() && strings.HasPrefix(request.response.Header.Get("Content-Type"), "text/event-stream") {
+				logEntry.LogTrafficMetric(time.Since(doTs).Nanoseconds(), 0, uint64(len(request.ResponseBody)), -1, req.URL.Path, "", "STREAM", "")
+			}
 		}
 	}()
 }


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

When a response is an http2 event stream the normal traffic metric will measure response time to first response. This adds an additional traffic metric with the response time until stream end.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
