### PR TITLE
Use custom ReadAll using globalbuffer for REST handler

### DIFF
--- a/helpers/BufferPool.go
+++ b/helpers/BufferPool.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"bytes"
+	"io"
 	"sync"
 )
 
@@ -28,4 +29,30 @@ func (bp *BufferPool) Get() *bytes.Buffer {
 func (bp *BufferPool) Put(buf *bytes.Buffer) {
 	buf.Reset()
 	bp.pool.Put(buf)
+}
+
+func ReadAll(r io.Reader) ([]byte, error) {
+	buf := GlobalBufferPool.Get()
+	defer GlobalBufferPool.Put(buf)
+
+	capacity := int64(bytes.MinRead)
+	var err error
+	// If the buffer overflows, we will get bytes.ErrTooLarge.
+	// Return that as an error. Any other panic remains.
+	defer func() {
+		e := recover()
+		if e == nil {
+			return
+		}
+		if panicErr, ok := e.(error); ok && panicErr == bytes.ErrTooLarge {
+			err = panicErr
+		} else {
+			panic(e)
+		}
+	}()
+	if int64(int(capacity)) == capacity {
+		buf.Grow(int(capacity))
+	}
+	_, err = buf.ReadFrom(r)
+	return buf.Bytes(), err
 }

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -648,7 +648,7 @@ func (handler *RestHandler) QueueRequestWithCallback(actionState *action.State, 
 			request.ResponseStatus = request.response.Status
 			request.ResponseStatusCode = request.response.StatusCode
 			request.ResponseHeaders = request.response.Header
-			request.ResponseBody, errRequest = io.ReadAll(request.response.Body)
+			request.ResponseBody, errRequest = ReadAll(request.response.Body)
 			// When content type is a stream normal metric log will be time to response without starting to stream the body. Thus this will log response time to stream end
 			if logEntry.ShouldLogTrafficMetrics() && strings.HasPrefix(request.response.Header.Get("Content-Type"), "text/event-stream") {
 				logEntry.LogTrafficMetric(time.Since(doTs).Nanoseconds(), 0, uint64(len(request.ResponseBody)), -1, req.URL.Path, "", "STREAM", "")

--- a/session/resthandler.go
+++ b/session/resthandler.go
@@ -648,7 +648,7 @@ func (handler *RestHandler) QueueRequestWithCallback(actionState *action.State, 
 			request.ResponseStatus = request.response.Status
 			request.ResponseStatusCode = request.response.StatusCode
 			request.ResponseHeaders = request.response.Header
-			request.ResponseBody, errRequest = ReadAll(request.response.Body)
+			request.ResponseBody, errRequest = helpers.ReadAll(request.response.Body)
 			// When content type is a stream normal metric log will be time to response without starting to stream the body. Thus this will log response time to stream end
 			if logEntry.ShouldLogTrafficMetrics() && strings.HasPrefix(request.response.Header.Get("Content-Type"), "text/event-stream") {
 				logEntry.LogTrafficMetric(time.Since(doTs).Nanoseconds(), 0, uint64(len(request.ResponseBody)), -1, req.URL.Path, "", "STREAM", "")
@@ -669,32 +669,6 @@ func (handler *RestHandler) addVirtualProxy(request *RestRequest) error {
 		request.Destination = destination
 	}
 	return nil
-}
-
-func ReadAll(r io.Reader) ([]byte, error) {
-	buf := helpers.GlobalBufferPool.Get()
-	defer helpers.GlobalBufferPool.Put(buf)
-
-	capacity := int64(bytes.MinRead)
-	var err error
-	// If the buffer overflows, we will get bytes.ErrTooLarge.
-	// Return that as an error. Any other panic remains.
-	defer func() {
-		e := recover()
-		if e == nil {
-			return
-		}
-		if panicErr, ok := e.(error); ok && panicErr == bytes.ErrTooLarge {
-			err = panicErr
-		} else {
-			panic(e)
-		}
-	}()
-	if int64(int(capacity)) == capacity {
-		buf.Grow(int(capacity))
-	}
-	_, err = buf.ReadFrom(r)
-	return buf.Bytes(), err
 }
 
 func prependURLPath(aURL, pathToPrepend string) (string, error) {

--- a/wsdialer/wsdialer.go
+++ b/wsdialer/wsdialer.go
@@ -191,7 +191,7 @@ func readMessage(r io.Reader, m []wsutil.Message, maxFrameSize int64) ([]wsutil.
 		State:     gobwas.StateClientSide,
 		CheckUTF8: true,
 		OnIntermediate: func(hdr gobwas.Header, src io.Reader) error {
-			bts, err := io.ReadAll(src)
+			bts, err := helpers.ReadAll(src)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Move ReadAll function using global pool buffer to helpers
Use ReadAll function instead of io.ReadAll for decrease memory allocation for REST handler and WS communication.


**Info**

mem profiling example for 10K users logging in and staying connected.

![image](https://github.com/user-attachments/assets/1212cffd-4de3-4c76-8842-8485c9d8897b)

