### PR TITLE
Use a Pool for timers in think time

### DIFF
--- a/helpers/timerpool.go
+++ b/helpers/timerpool.go
@@ -1,0 +1,33 @@
+package helpers
+
+import (
+	"sync"
+	"time"
+)
+
+type (
+	TimerPool struct {
+		pool sync.Pool
+	}
+)
+
+var GlobalTimerPool = NewTimerPool()
+
+func NewTimerPool() *TimerPool {
+	return &TimerPool{sync.Pool{New: newTimer}}
+}
+
+func newTimer() any {
+	return time.NewTimer(0)
+}
+
+func (tp *TimerPool) Get(delay time.Duration) *time.Timer {
+	tmr := tp.pool.Get().(*time.Timer)
+	tmr.Reset(delay)
+	return tmr
+}
+
+func (tp *TimerPool) Put(timer *time.Timer) {
+	timer.Stop()
+	tp.pool.Put(timer)
+}

--- a/helpers/timerpool_test.go
+++ b/helpers/timerpool_test.go
@@ -1,0 +1,26 @@
+package helpers_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/qlik-oss/gopherciser/helpers"
+)
+
+func TestTimerPool(t *testing.T) {
+	refTime := 50 * time.Millisecond
+
+	t1 := helpers.GlobalTimerPool.Get(refTime)
+	helpers.GlobalTimerPool.Put(t1)
+
+	t1 = helpers.GlobalTimerPool.Get(2 * refTime)
+	ts := time.Now()
+	<-t1.C
+	dur := time.Since(ts)
+	if dur < 2*refTime {
+		t.Fatal("timer ticked to fast")
+	}
+	if dur > time.Duration(1.1*float64(2*refTime)) {
+		t.Fatal("timer took more than 10% longer than expected")
+	}
+}

--- a/helpers/timerpool_test.go
+++ b/helpers/timerpool_test.go
@@ -24,3 +24,19 @@ func TestTimerPool(t *testing.T) {
 		t.Fatal("timer took more than 10% longer than expected")
 	}
 }
+
+func BenchmarkTimerPool(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		tmr := helpers.GlobalTimerPool.Get(time.Millisecond)
+		<-tmr.C
+		helpers.GlobalTimerPool.Put(tmr)
+	}
+}
+
+func BenchmarkTimer(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		tmr := time.NewTimer(time.Millisecond)
+		<-tmr.C
+		tmr.Stop()
+	}
+}

--- a/scenario/thinktime.go
+++ b/scenario/thinktime.go
@@ -40,8 +40,8 @@ func (settings ThinkTimeSettings) Execute(sessionState *session.State, actionSta
 	}
 
 	// "Think"
-	timer := time.NewTimer(delay)
-	defer timer.Stop()
+	timer := helpers.GlobalTimerPool.Get(delay)
+	defer helpers.GlobalTimerPool.Put(timer)
 	select {
 	case <-sessionState.BaseContext().Done():
 		// returning without updating end time makes log result log info: aborted instead of result: true


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Descriptive text which shall be used as squash commit message to master.

**Info**
Somewhat unfair benchmarks but shows best case scenario

```
BenchmarkTimerPool-8         892           1390724 ns/op                  1 B/op          0 allocs/op
BenchmarkTimer-8                896           1386008 ns/op             248 B/op          3 allocs/op
```