### PR TITLE
Default build to Go 1.24, bump circleci resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ jobs:
   build:
     <<: *defaults
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.24
+    resource_class: large
     steps:
       - checkout
       - setup_remote_docker
@@ -20,7 +21,7 @@ jobs:
             set -x
             mkdir -p build
       - restore_cache:
-          key: dependency-cache-1.23{{ checksum "go.sum" }}
+          key: dependency-cache-1.24{{ checksum "go.sum" }}
       - run:
           name: Run Golang tests
           command: |
@@ -40,7 +41,7 @@ jobs:
           command: |
             make build
       - save_cache:
-          key: dependency-cache-1.23{{ checksum "go.sum" }}
+          key: dependency-cache-1.24{{ checksum "go.sum" }}
           paths:
             - "/home/circleci/go/pkg/mod"
       - run:
@@ -82,6 +83,7 @@ jobs:
         default: "1.23"
     docker:
       - image: cimg/go:<< parameters.version >>
+    resource_class: large
     steps:
       - checkout
       - run:
@@ -147,7 +149,7 @@ jobs:
   build-publish-docker:
     <<: *defaults
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.24
     steps:
       - checkout
       - setup_remote_docker
@@ -192,6 +194,9 @@ workflows:
           filters:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+/
+      - test-go-version:
+          name: "Test Go 1.23"
+          version: "1.23"
       - test-go-version:
           name: "Test Go 1.24"
           version: "1.24"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,9 +195,6 @@ workflows:
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+/
       - test-go-version:
-          name: "Test Go 1.23"
-          version: "1.23"
-      - test-go-version:
           name: "Test Go 1.24"
           version: "1.24"
       - publish-github:

--- a/.github/workflows/check-generate-docs.yaml
+++ b/.github/workflows/check-generate-docs.yaml
@@ -10,6 +10,9 @@ jobs:
   checkdocs:
     name: Verify generated
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publishwiki.yaml
+++ b/.github/workflows/publishwiki.yaml
@@ -9,6 +9,8 @@ jobs:
   generatewiki:
     name: Generate WIKI
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

```
* Bumps circleci docker to large
* Bumps default build to Go 1.24
* Add permissions field to github actions
```

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
