### PR TITLE
Bugfix for api stats counter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -918,7 +917,7 @@ func summary(log *logger.Log, summary SummaryType, startTime time.Time, counters
 			if failed < 1 {
 				successRate = 100.0
 			} else {
-				successRate = successful / (successful + float64(failed)) * 100
+				successRate = float64(successful) / float64(successful+failed) * 100
 			}
 		}
 
@@ -989,7 +988,7 @@ func summary(log *logger.Log, summary SummaryType, startTime time.Time, counters
 			Method:   stats.Method(),
 			Path:     stats.Path(),
 			AvgResp:  time.Duration(resp).Round(time.Millisecond).String(),
-			Requests: fmt.Sprintf("%d", uint64(math.Round(requests))),
+			Requests: strconv.FormatUint(requests, 10),
 			Sent:     stats.Sent.String(),
 			Received: stats.Received.String(),
 		}

--- a/statistics/executionCounters_test.go
+++ b/statistics/executionCounters_test.go
@@ -56,7 +56,9 @@ func TestCounters(t *testing.T) {
 
 func collectorTest(t *testing.T, def collectTestDef) {
 	collector := NewCollector()
-	collector.SetLevel(StatsLevelFull)
+	if err := collector.SetLevel(StatsLevelFull); err != nil {
+		t.Fatal(err)
+	}
 
 	if collector.Level != StatsLevelFull {
 		t.Errorf("incorrect stats level: %v", collector.Level)
@@ -86,8 +88,8 @@ func collectorTest(t *testing.T, def collectTestDef) {
 			}
 
 			average, requests := stats.RespAvg.Average()
-			if !helpers.NearlyEqual(requests, float64(sample.Count)) {
-				t.Errorf("path<%s> expected sample count<%d> got<%f>", sample.Path, sample.Count, requests)
+			if requests != sample.Count {
+				t.Errorf("path<%s> expected sample count<%d> got<%d>", sample.Path, sample.Count, requests)
 			}
 			if !helpers.NearlyEqual(average, float64(sample.Size)) {
 				t.Errorf("path<%s> expected average<%d> got<%f>", sample.Path, sample.Size, average)

--- a/statistics/executionCounters_test.go
+++ b/statistics/executionCounters_test.go
@@ -1,0 +1,38 @@
+package statistics
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCounters(t *testing.T) {
+	collector := NewCollector()
+	collector.SetLevel(StatsLevelFull)
+	t.Log("collector level is full:", collector.IsFull())
+	t.Log("collector is on:", collector.IsOn())
+
+	if collector.Level != StatsLevelFull {
+		t.Fatalf("incorrect stats level: %v", collector.Level)
+	}
+
+	if !collector.IsOn() {
+		t.Fatalf("collector not on")
+	}
+
+	n := 10148
+	var stats *RequestStats
+	for range n {
+		stats = collector.GetOrAddRequestStats("head", "/test/path/1")
+		if stats == nil {
+			t.Fatal("stats returned nil")
+		}
+		stats.RespAvg.AddSample(uint64(123456))
+	}
+
+	_, requests := stats.RespAvg.Average()
+	current := uint64(math.Round(requests))
+	expected := uint64(n)
+	if current != expected {
+		t.Errorf("expected<%d> got<%d>", expected, current)
+	}
+}

--- a/statistics/executionCounters_test.go
+++ b/statistics/executionCounters_test.go
@@ -31,7 +31,7 @@ func TestCounters(t *testing.T) {
 			},
 		},
 		{
-			Name: "2 path 2048 samples",
+			Name: "2 paths 2048 samples",
 			Samples: []collectTestDefSamples{
 				{
 					Count: 1024,
@@ -42,6 +42,26 @@ func TestCounters(t *testing.T) {
 					Count: 1024,
 					Path:  "/test/path/2",
 					Size:  12345678,
+				},
+			},
+		},
+		{
+			Name: "large sample count",
+			Samples: []collectTestDefSamples{
+				{
+					Count: 64000000,
+					Path:  "/test/path/1",
+					Size:  12345,
+				},
+			},
+		},
+		{
+			Name: "large sample size",
+			Samples: []collectTestDefSamples{
+				{
+					Count: 1024,
+					Path:  "/test/path/1",
+					Size:  1024 * 1024 * 1024,
 				},
 			},
 		},

--- a/statistics/samplecollector.go
+++ b/statistics/samplecollector.go
@@ -73,13 +73,6 @@ func (collector *SampleCollector) emptyHotBuffer() {
 		newSum += float64(v)
 	}
 
-	// first time around ?
-	if collector.count < 1 {
-		collector.curAvg = newSum / newCount
-		collector.count = newCount
-		return
-	}
-
 	// avoiding (curAvg*count + newAvg*newCount)/(count+newCount) for overflow protection, below equation equates to the same value
 	collector.curAvg = collector.curAvg/(1+newCount/collector.count) + newSum/(collector.count+newCount)
 	collector.count += newCount

--- a/statistics/samplecollector.go
+++ b/statistics/samplecollector.go
@@ -11,7 +11,7 @@ type (
 		bufLock sync.Mutex
 
 		curAvg         float64
-		count          float64
+		count          uint64
 		bufPurgeExpiry time.Duration
 		bufPurgeTs     time.Time
 	}
@@ -61,9 +61,9 @@ func (collector *SampleCollector) AddSample(sample uint64) {
 
 // emptyHotBuffer should only be called by function holding collector.bufLock
 func (collector *SampleCollector) emptyHotBuffer() {
-	newCount := float64(len(collector.hotBuf))
+	newCount := uint64(len(collector.hotBuf))
 
-	if newCount < 0.5 {
+	if newCount < 1 {
 		// nothing in buffer
 		return
 	}
@@ -74,14 +74,14 @@ func (collector *SampleCollector) emptyHotBuffer() {
 	}
 
 	// avoiding (curAvg*count + newAvg*newCount)/(count+newCount) for overflow protection, below equation equates to the same value
-	collector.curAvg = collector.curAvg/(1+newCount/collector.count) + newSum/(collector.count+newCount)
+	collector.curAvg = collector.curAvg/(1+float64(newCount)/float64(collector.count)) + newSum/float64(collector.count+newCount)
 	collector.count += newCount
 	collector.hotBuf = collector.hotBuf[0:0]
 	collector.bufPurgeTs = time.Now().Add(collector.bufPurgeExpiry)
 }
 
 // Average empties hot buffer and calculates current running average, returns average, total samples.
-func (collector *SampleCollector) Average() (float64, float64) {
+func (collector *SampleCollector) Average() (float64, uint64) {
 	defer collector.bufLock.Unlock()
 	collector.bufLock.Lock()
 


### PR DESCRIPTION
**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**
Changes for collection stats counter
* Bugfix: unnecessary "first time around" caused counter to eventually get incorrect value when hot buffer was emptied
* Added unit tests
* Changed sample counter to use uint64 storage and only float64 when doing calculations (although not necessary for bugfix, it will improve logic for large numbers)

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
