### PR TITLE
Make config helpers public

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -272,12 +272,12 @@ func init() {
 func execute() error {
 
 	// === config section ===
-	cfg, errUnmarshal := unmarshalConfigFile()
+	cfg, errUnmarshal := UnmarshalConfigFile()
 	if errUnmarshal != nil {
 		return JSONParseError(errUnmarshal.Error())
 	}
 
-	if err := validateConfigAndPrintWarnings(cfg); err != nil {
+	if err := ValidateConfigAndPrintWarnings(cfg); err != nil {
 		return JSONValidateError(err.Error())
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -59,7 +59,7 @@ func AddLoggingParameters(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&summaryType, "summary", "", getSummaryTypeHelpString())
 }
 
-func unmarshalConfigFile() (*config.Config, error) {
+func UnmarshalConfigFile() (*config.Config, error) {
 	var err error
 	var cfgJSON []byte
 	var hasPipe bool
@@ -118,6 +118,28 @@ func cfgJsonFromFile() ([]byte, error) {
 	}
 
 	return os.ReadFile(cfgFile)
+}
+
+func ValidateConfigAndPrintWarnings(cfg *config.Config) error {
+	err := cfg.Validate()
+	if err != nil {
+		return err
+	}
+
+	warningsCount := len(cfg.ValidationWarnings)
+	if warningsCount < 1 {
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "%d script validation warnings:\n", warningsCount)
+	for i, warning := range cfg.ValidationWarnings {
+		_, _ = fmt.Fprintf(os.Stderr, "%d. %s\n", i+1, warning)
+		if i == 9 {
+			_, _ = fmt.Fprintf(os.Stderr, "...(%d) additional warnings\n", warningsCount-i+1)
+			return nil
+		}
+	}
+	return nil
 }
 
 func overrideScriptValues(cfgJSON []byte, hasPipe bool) ([]byte, []string, error) {

--- a/cmd/script.go
+++ b/cmd/script.go
@@ -110,13 +110,13 @@ var validateCmd = &cobra.Command{
 	Short:   "validate a scenario config file",
 	Long:    `validate a scenario config file`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := unmarshalConfigFile()
+		cfg, err := UnmarshalConfigFile()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(ExitCodeJSONParseError)
 		}
 
-		if err := validateConfigAndPrintWarnings(cfg); err != nil {
+		if err := ValidateConfigAndPrintWarnings(cfg); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(ExitCodeJSONValidateError)
 		}
@@ -140,7 +140,7 @@ var testConnectionCmd = &cobra.Command{
 	Short:   "test connection",
 	Long:    `test connection using settings provided by the config file`,
 	Run: func(cmd *cobra.Command, args []string) {
-		cfg, err := unmarshalConfigFile()
+		cfg, err := UnmarshalConfigFile()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
 			os.Exit(ExitCodeJSONParseError)
@@ -168,7 +168,7 @@ Will save one .structure file per app in script in the folder defined by output 
 			os.Exit(ExitCodeObjectDefError)
 		}
 
-		cfg, err := unmarshalConfigFile()
+		cfg, err := UnmarshalConfigFile()
 		if err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %+v\n", err)
 			os.Exit(ExitCodeJSONParseError)
@@ -196,24 +196,3 @@ Will save one .structure file per app in script in the folder defined by output 
 	},
 }
 
-func validateConfigAndPrintWarnings(cfg *config.Config) error {
-	err := cfg.Validate()
-	if err != nil {
-		return err
-	}
-
-	warningsCount := len(cfg.ValidationWarnings)
-	if warningsCount < 1 {
-		return nil
-	}
-
-	_, _ = fmt.Fprintf(os.Stderr, "%d script validation warnings:\n", warningsCount)
-	for i, warning := range cfg.ValidationWarnings {
-		_, _ = fmt.Fprintf(os.Stderr, "%d. %s\n", i+1, warning)
-		if i == 9 {
-			_, _ = fmt.Fprintf(os.Stderr, "...(%d) additional warnings\n", warningsCount-i+1)
-			return nil
-		}
-	}
-	return nil
-}


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [ ] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Making config helpers public

**Info**

Making config helpers public so that we can reuse them outside of the oss cmd module instead of rewriting if extending. No functionality changes, and as they were not public before no compatibility issues can arise.