### PR TITLE
App structure: Resolve string expression for title,subtile and footnote

### DIFF
--- a/config/appstructure.go
+++ b/config/appstructure.go
@@ -662,26 +662,25 @@ func (structure *GeneratedAppStructure) handleObject(typ string, obj *appstructu
 		obj.Selectable = false
 	}
 
-	resolveTitle(obj, properties, []string{
-		"/title",
-		fmt.Sprintf("%sDef/qTitle", def.DataDef.Path),
-	})
-
+	// 	fmt.Sprintf("%sDef/qTitle", def.DataDef.Path),
+	obj.Title = resolvePossibleStringExpression(properties, "/title")
 	// add subtitle
-	dpSubTitle := helpers.NewDataPath("/subtitle")
-	subtitle, _ := dpSubTitle.LookupNoQuotes(properties)
-	if subtitle != nil {
-		obj.SubTitle = string(subtitle)
-	}
-
+	obj.SubTitle = resolvePossibleStringExpression(properties, "/subtitle")
 	// add footnote
-	dpFootnote := helpers.NewDataPath("/footnote")
-	footnote, _ := dpFootnote.LookupNoQuotes(properties)
-	if footnote != nil {
-		obj.Footnote = string(footnote)
-	}
+	obj.Footnote = resolvePossibleStringExpression(properties, "/footnote")
 
 	return nil
+}
+
+func resolvePossibleStringExpression(properties json.RawMessage, path string) string {
+	dp := helpers.NewDataPath(path)
+	data, _ := dp.Lookup(properties)
+
+	var stringExpression helpers.StringExpression
+	if err := json.Unmarshal(data, &stringExpression); err != nil {
+		return string(data) // fallback
+	}
+	return string(stringExpression)
 }
 
 func (structure *GeneratedAppStructure) handleMeasure(ctx context.Context, app *senseobjects.App, id, typ string, obj *appstructure.AppStructureObject) error {
@@ -966,28 +965,6 @@ func (structure *GeneratedAppStructure) addSheetMeta(layout *senseobjects.SheetL
 
 func (structure *GeneratedAppStructure) GetWarningsList() []AppStructureWarning {
 	return structure.report.warnings
-}
-
-func resolveTitle(obj *appstructure.AppStructureObject, properties json.RawMessage, paths []string) {
-	if obj.Title != "" {
-		return // We already have a title
-	}
-
-	for _, path := range paths {
-		title := stringFromDataPath(path, properties)
-		if title != "" {
-			obj.Title = title
-			return
-		}
-	}
-}
-
-func stringFromDataPath(path string, data json.RawMessage) string {
-	dataPath := helpers.NewDataPath(path)
-	rawData, _ := dataPath.Lookup(data)
-	var str string
-	_ = json.Unmarshal(rawData, &str)
-	return str
 }
 
 // AddWarning to app structure report

--- a/helpers/stringexpression.go
+++ b/helpers/stringexpression.go
@@ -1,0 +1,62 @@
+package helpers
+
+import (
+	"strings"
+
+	"github.com/goccy/go-json"
+	"github.com/qlik-oss/enigma-go/v4"
+)
+
+type (
+	stringExpression struct {
+		Expression *enigma.StringExpression `json:"qStringExpression"`
+	}
+
+	StringExpression string
+)
+
+// unmarshals quoted(!) string or string expression object
+func (expr *StringExpression) UnmarshalJSON(arg []byte) error {
+	if expr == nil || len(arg) < 1 {
+		return nil
+	}
+	switch arg[0] {
+	case '{':
+		var se stringExpression
+		if err := json.Unmarshal(arg, &se); err != nil {
+			*expr = StringExpression(arg) // fallback
+		}
+		*expr = StringExpression(se.Expression.Expr)
+	case '"':
+		*expr = StringExpression(strings.TrimPrefix(strings.TrimSuffix(string(arg), `"`), `"`))
+	default:
+		*expr = StringExpression(arg)
+	}
+	return nil
+}
+
+func (expr StringExpression) MarshalJSON() ([]byte, error) {
+	if len(expr) < 1 {
+		return []byte{}, nil
+	}
+
+	switch []rune(expr)[0] {
+	case '=', '\'':
+		return json.Marshal(stringExpression{
+			Expression: &enigma.StringExpression{
+				Expr: string(expr),
+			},
+		})
+	default:
+		return []byte(expr), nil
+	}
+}
+
+// // MarshalJSON marshal HttpMethod
+// func (method HttpMethod) MarshalJSON() ([]byte, error) {
+// 	str, err := httpMethodEnum.String(int(method))
+// 	if err != nil {
+// 		return nil, errors.Errorf("Unknown HttpMethod<%d>", method)
+// 	}
+// 	return []byte(fmt.Sprintf(`"%s"`, str)), nil
+// }

--- a/helpers/stringexpression.go
+++ b/helpers/stringexpression.go
@@ -51,12 +51,3 @@ func (expr StringExpression) MarshalJSON() ([]byte, error) {
 		return []byte(expr), nil
 	}
 }
-
-// // MarshalJSON marshal HttpMethod
-// func (method HttpMethod) MarshalJSON() ([]byte, error) {
-// 	str, err := httpMethodEnum.String(int(method))
-// 	if err != nil {
-// 		return nil, errors.Errorf("Unknown HttpMethod<%d>", method)
-// 	}
-// 	return []byte(fmt.Sprintf(`"%s"`, str)), nil
-// }

--- a/helpers/stringexpression_test.go
+++ b/helpers/stringexpression_test.go
@@ -1,0 +1,116 @@
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/qlik-oss/gopherciser/helpers"
+)
+
+func TestStringExpression_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		arg        []byte
+		wantErr    bool
+		wantResult string
+	}{
+		{
+			name:       "Quoted string",
+			arg:        []byte(`"myexpr1"`),
+			wantErr:    false,
+			wantResult: "myexpr1",
+		},
+		{
+			name:       "Unquoted string",
+			arg:        []byte(`myexpr2"`),
+			wantErr:    false,
+			wantResult: "myexpr2\"",
+		},
+		{
+			name:       "Unquoted string with quotes",
+			arg:        []byte(`\"myexpr2\"`),
+			wantErr:    false,
+			wantResult: `\"myexpr2\"`,
+		},
+		{
+			name:       "Expression object",
+			arg:        []byte(`{"qStringExpression":{"qExpr":"myexpr3"}}`),
+			wantErr:    false,
+			wantResult: "myexpr3",
+		},
+		{
+			name:       "empty string",
+			arg:        []byte{},
+			wantErr:    false,
+			wantResult: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var expr helpers.StringExpression
+			gotErr := expr.UnmarshalJSON(tt.arg)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("UnmarshalJSON() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("UnmarshalJSON() succeeded unexpectedly")
+			} else if expr != helpers.StringExpression(tt.wantResult) {
+				t.Errorf("Unexpected result<%s> wanted<%s>", expr, tt.wantResult)
+			}
+		})
+	}
+}
+
+func TestStringExpression_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string // description of this test case
+		input   helpers.StringExpression
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "string",
+			input:   helpers.StringExpression("mystring"),
+			want:    []byte("mystring"),
+			wantErr: false,
+		},
+		{
+			name:    "expr with =",
+			input:   helpers.StringExpression("='myexpr1'"),
+			want:    []byte(`{"qStringExpression":{"qExpr":"='myexpr1'"}}`),
+			wantErr: false,
+		},
+		{
+			name:    "expr without =",
+			input:   helpers.StringExpression("'myexpr2'"),
+			want:    []byte(`{"qStringExpression":{"qExpr":"'myexpr2'"}}`),
+			wantErr: false,
+		},
+		{
+			name:    "empty string",
+			input:   helpers.StringExpression(""),
+			want:    []byte{},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := tt.input.MarshalJSON()
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("MarshalJSON() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("MarshalJSON() succeeded unexpectedly")
+			}
+			if string(tt.want) != string(got) {
+				t.Errorf("MarshalJSON() result<%s>, want<%s>", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changes to handling of title, subtile and foot note for app structure

* Resolve possible string expression for title,subtile and footnote
* Remove support for old title location

Pure string still resolves same way, e.g: 

```
      "title": "string title",
      "subtitle": "string subtitle",
      "footnote": "string footnote",
```
However titles with expression changes, old (title became empty and thus missing):

```
      "subtitle": "{\"qStringExpression\":{\"qExpr\":\"'sub title with expression and no equal sign'\"}}",
      "footnote": "{\"qStringExpression\":{\"qExpr\":\"='footnote with expression'\"}}",
```

new

```
      "title": "='title with expresssion'",
      "subtitle": "'sub title with expression and no equal sign'",
      "footnote": "='footnote with expression'",
```

**Checklist**

- [x] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

Descriptive text which shall be used as squash commit message to master.

**Info**

Optional informative text (not to be included in commit message) relevant to reviewers.
