### PR TITLE
Replace timebased tests with synctest

### DIFF
--- a/helpers/timerpool_test.go
+++ b/helpers/timerpool_test.go
@@ -2,27 +2,27 @@ package helpers_test
 
 import (
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/qlik-oss/gopherciser/helpers"
 )
 
 func TestTimerPool(t *testing.T) {
-	refTime := 50 * time.Millisecond
+	synctest.Test(t, func(t *testing.T) {
+		refTime := 50 * time.Millisecond
 
-	t1 := helpers.GlobalTimerPool.Get(refTime)
-	helpers.GlobalTimerPool.Put(t1)
+		t1 := helpers.GlobalTimerPool.Get(refTime)
+		helpers.GlobalTimerPool.Put(t1)
 
-	t1 = helpers.GlobalTimerPool.Get(2 * refTime)
-	ts := time.Now()
-	<-t1.C
-	dur := time.Since(ts)
-	if dur < 2*refTime {
-		t.Fatal("timer ticked to fast")
-	}
-	if dur > time.Duration(1.1*float64(2*refTime)) {
-		t.Fatal("timer took more than 10% longer than expected")
-	}
+		t1 = helpers.GlobalTimerPool.Get(2 * refTime)
+		ts := time.Now()
+		<-t1.C
+		dur := time.Since(ts)
+		if dur != 2*refTime {
+			t.Fatalf("timer fired after<%v> expected<%v>", dur, 2*refTime)
+		}
+	})
 }
 
 func BenchmarkTimerPool(b *testing.B) {

--- a/helpers/workerpool_test.go
+++ b/helpers/workerpool_test.go
@@ -1,40 +1,38 @@
 package helpers_test
 
-// Disabling test due to go 1.25 has memory leak bug, should be re-enabled once bumping back up to >1.24
-// import (
-// 	"testing"
-// 	"testing/synctest"
-// 	"time"
+import (
+	"testing"
+	"testing/synctest"
+	"time"
 
-// 	"github.com/qlik-oss/gopherciser/helpers"
-// )
+	"github.com/qlik-oss/gopherciser/helpers"
+)
 
-// func TestWorkerPool(t *testing.T) {
-// 	synctest.Test(t, func(t *testing.T) {
-// 		total := 10
-// 		concurrency := 2
-// 		pool, err := helpers.NewWorkerPool(concurrency, total)
-// 		if err != nil {
-// 			t.Fatal(err)
-// 		}
-// 		for i := range total {
-// 			if err := pool.AddTask(func() error {
-// 				time.Sleep(time.Duration(i) * time.Second)
-// 				return nil
-// 			}); err != nil {
-// 				t.Error(err)
-// 			}
-// 		}
-// 		totalResult := 0
-// 		for result := range pool.Results() {
-// 			totalResult++
-// 			if result != nil {
-// 				t.Error(result)
-// 			}
-// 		}
-// 		if totalResult != total {
-// 			t.Errorf("total results<%d> expected<%d>", totalResult, total)
-// 		}
-// 	})
-
-// }
+func TestWorkerPool(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		total := 10
+		concurrency := 2
+		pool, err := helpers.NewWorkerPool(concurrency, total)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := range total {
+			if err := pool.AddTask(func() error {
+				time.Sleep(time.Duration(i) * time.Second)
+				return nil
+			}); err != nil {
+				t.Error(err)
+			}
+		}
+		totalResult := 0
+		for result := range pool.Results() {
+			totalResult++
+			if result != nil {
+				t.Error(result)
+			}
+		}
+		if totalResult != total {
+			t.Errorf("total results<%d> expected<%d>", totalResult, total)
+		}
+	})
+}

--- a/scheduler/timebuffer_test.go
+++ b/scheduler/timebuffer_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/goccy/go-json"
@@ -10,96 +11,90 @@ import (
 )
 
 func TestTimeBufConstant(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
-
-	timeBuf := TimeBuffer{
-		Mode:     TimeBufConstant,
-		Duration: helpers.TimeDuration(time.Second),
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	if err := timeBuf.Wait(ctx, false); err != nil {
-		t.Errorf("Error waiting: %+v", err)
-	}
-	if helpers.IsContextTriggered(ctx) {
-		t.Error("context was triggered for mode TimeBufConstant")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		timeBuf := TimeBuffer{
+			Mode:     TimeBufConstant,
+			Duration: helpers.TimeDuration(time.Second),
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		if err := timeBuf.Wait(ctx, false); err != nil {
+			t.Errorf("Error waiting: %+v", err)
+		}
+		if helpers.IsContextTriggered(ctx) {
+			t.Error("context was triggered for mode TimeBufConstant")
+		}
+	})
 }
 
 func TestTimeBufMinDur(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		timeBuf := TimeBuffer{
+			Mode:     TimeBufMinDur,
+			Duration: helpers.TimeDuration(2 * time.Second),
+		}
 
-	timeBuf := TimeBuffer{
-		Mode:     TimeBufMinDur,
-		Duration: helpers.TimeDuration(2 * time.Second),
-	}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		expectedError := "illegal start time<0001-01-01 00:00:00 +0000 UTC>"
+		if err := timeBuf.Wait(ctx, false); err == nil || err.Error() != expectedError {
+			t.Errorf("Expected error<%s>  got: %+v", expectedError, err)
+		}
+		if helpers.IsContextTriggered(ctx) {
+			t.Error("context was triggered for mode TimeBufConstant")
+		}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	expectedError := "illegal start time<0001-01-01 00:00:00 +0000 UTC>"
-	if err := timeBuf.Wait(ctx, false); err == nil || err.Error() != expectedError {
-		t.Errorf("Expected error<%s>  got: %+v", expectedError, err)
-	}
-	if helpers.IsContextTriggered(ctx) {
-		t.Error("context was triggered for mode TimeBufConstant")
-	}
+		now := time.Now()
+		timeBuf.SetDurationStart(now)
+		time.Sleep(time.Millisecond * 500)
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		if err := timeBuf.Wait(ctx, false); err != nil {
+			t.Errorf("Error waiting: %+v", err)
+		}
 
-	now := time.Now()
-	timeBuf.SetDurationStart(now)
-	<-time.After(time.Millisecond * 500)
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	if err := timeBuf.Wait(ctx, false); err != nil {
-		t.Errorf("Error waiting: %+v", err)
-	}
-
-	if now.Add(2 * time.Second).After(time.Now()) {
-		t.Error("duration less than expected 2 seconds")
-	}
-	if helpers.IsContextTriggered(ctx) {
-		t.Error("context was triggered for mode TimeBufConstant")
-	}
+		if now.Add(2 * time.Second).After(time.Now()) {
+			t.Error("duration less than expected 2 seconds")
+		}
+		if helpers.IsContextTriggered(ctx) {
+			t.Error("context was triggered for mode TimeBufConstant")
+		}
+	})
 }
 
 func TestTimeBufOnError(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode.")
-	}
+	synctest.Test(t, func(t *testing.T) {
+		timeBuf := TimeBuffer{
+			Mode:     TimeBufOnError,
+			Duration: helpers.TimeDuration(time.Second),
+		}
 
-	timeBuf := TimeBuffer{
-		Mode:     TimeBufOnError,
-		Duration: helpers.TimeDuration(time.Second),
-	}
+		start := time.Now()
+		// test no errors
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		if err := timeBuf.Wait(ctx, false); err != nil {
+			t.Errorf("Error waiting: %+v", err)
+		}
+		if helpers.IsContextTriggered(ctx) {
+			t.Error("context was triggered for mode TimeBufConstant")
+		}
+		if start.Add(time.Second + 50*time.Millisecond).Before(time.Now()) {
+			t.Error("mode<TimeBufOnError> waited despite errors false")
+		}
 
-	start := time.Now()
-	// test no errors
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	if err := timeBuf.Wait(ctx, false); err != nil {
-		t.Errorf("Error waiting: %+v", err)
-	}
-	if helpers.IsContextTriggered(ctx) {
-		t.Error("context was triggered for mode TimeBufConstant")
-	}
-	if start.Add(time.Second + 50*time.Millisecond).Before(time.Now()) {
-		t.Error("mode<TimeBufOnError> waited despite errors false")
-	}
-
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	if err := timeBuf.Wait(ctx, true); err != nil {
-		t.Errorf("Error waiting: %+v", err)
-	}
-	if helpers.IsContextTriggered(ctx) {
-		t.Error("context was triggered for mode TimeBufConstant")
-	}
-	if start.Add(time.Second).After(time.Now()) {
-		t.Error("mode<TimeBufOnError> did not wait despite errors true")
-	}
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		if err := timeBuf.Wait(ctx, true); err != nil {
+			t.Errorf("Error waiting: %+v", err)
+		}
+		if helpers.IsContextTriggered(ctx) {
+			t.Error("context was triggered for mode TimeBufConstant")
+		}
+		if start.Add(time.Second).After(time.Now()) {
+			t.Error("mode<TimeBufOnError> did not wait despite errors true")
+		}
+	})
 }
 
 func TestTimeBufMarshaling(t *testing.T) {

--- a/scheduler/timebuffer_test.go
+++ b/scheduler/timebuffer_test.go
@@ -41,7 +41,7 @@ func TestTimeBufMinDur(t *testing.T) {
 			t.Errorf("Expected error<%s>  got: %+v", expectedError, err)
 		}
 		if helpers.IsContextTriggered(ctx) {
-			t.Error("context was triggered for mode TimeBufConstant")
+			t.Error("context was triggered for mode TimeBufMinDur")
 		}
 
 		now := time.Now()
@@ -57,7 +57,7 @@ func TestTimeBufMinDur(t *testing.T) {
 			t.Error("duration less than expected 2 seconds")
 		}
 		if helpers.IsContextTriggered(ctx) {
-			t.Error("context was triggered for mode TimeBufConstant")
+			t.Error("context was triggered for mode TimeBufMinDur")
 		}
 	})
 }
@@ -77,9 +77,9 @@ func TestTimeBufOnError(t *testing.T) {
 			t.Errorf("Error waiting: %+v", err)
 		}
 		if helpers.IsContextTriggered(ctx) {
-			t.Error("context was triggered for mode TimeBufConstant")
+			t.Error("context was triggered for mode TimeBufOnError")
 		}
-		if start.Add(time.Second + 50*time.Millisecond).Before(time.Now()) {
+		if start.Add(time.Second).Before(time.Now()) {
 			t.Error("mode<TimeBufOnError> waited despite errors false")
 		}
 
@@ -89,7 +89,7 @@ func TestTimeBufOnError(t *testing.T) {
 			t.Errorf("Error waiting: %+v", err)
 		}
 		if helpers.IsContextTriggered(ctx) {
-			t.Error("context was triggered for mode TimeBufConstant")
+			t.Error("context was triggered for mode TimeBufOnError")
 		}
 		if start.Add(time.Second).After(time.Now()) {
 			t.Error("mode<TimeBufOnError> did not wait despite errors true")


### PR DESCRIPTION
**Checklist**

- [ ] tests added
- [x] commits conform to the [Commit message format](https://github.com/qlik-oss/gopherciser/blob/master/.github/CONTRIBUTING.md#commit)
- [ ] documentation updated


**Squash commit message**

implement time base tests using synctest instead.

**Info**

comparison running `time go test --count=10 ./... -run "TestTimerPool|TestTimeBufConstant|TestTimeBufMinDur|TestTimeBufOnError"` 40s vs 0.6s